### PR TITLE
expand pre-commit hook: lint, fmt, typecheck, test

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
 cd "$(git rev-parse --show-toplevel)"
-pnpm exec oxlint || exit 1
-pnpm --filter @github-dashboard/web exec vitest run || exit 1
+pnpm lint || exit 1
+pnpm fmt:check || exit 1
+pnpm typecheck || exit 1
+pnpm test || exit 1

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Pre-commit now runs `pnpm lint`, `pnpm fmt:check`, `pnpm typecheck`, `pnpm test` (was: lint + vitest only).
- Pinned web's `test` script to `vitest run` so `pnpm test` always single-runs.

Closes #6, closes #7.

## Test plan
- [x] `.husky/pre-commit` runs cleanly end-to-end (~2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)