### PR TITLE
add backend test coverage (74 tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm --filter @github-dashboard/web test",
+    "test": "pnpm -r test",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsgo",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.1",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "tsx": "^4.19.3"
+    "tsx": "^4.19.3",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/server/src/cache.test.ts
+++ b/packages/server/src/cache.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FsMock } from "./test-utils/fs-mock.js";
+
+vi.mock("node:fs", async () => {
+  const { createFsMock } = await import("./test-utils/fs-mock.js");
+  return createFsMock();
+});
+
+async function freshCache() {
+  vi.resetModules();
+  return import("./cache.js");
+}
+
+async function getFsMock(): Promise<FsMock> {
+  return (await import("node:fs")) as unknown as FsMock;
+}
+
+beforeEach(async () => {
+  (await getFsMock()).__store.clear();
+  vi.clearAllMocks();
+});
+
+describe("cache in-memory", () => {
+  it("returns null for missing key", async () => {
+    const { getCached } = await freshCache();
+    expect(getCached("missing")).toBeNull();
+  });
+
+  it("roundtrips data via set/get", async () => {
+    const { getCached, setCached } = await freshCache();
+    setCached("k", { a: 1 });
+    expect(getCached<{ a: number }>("k")).toEqual({ a: 1 });
+  });
+
+  it("cacheAge is null when key is missing", async () => {
+    const { cacheAge } = await freshCache();
+    expect(cacheAge("missing")).toBeNull();
+  });
+
+  it("cacheAge is near-zero immediately after setCached", async () => {
+    const { setCached, cacheAge } = await freshCache();
+    setCached("k", 1);
+    const age = cacheAge("k");
+    expect(age).not.toBeNull();
+    expect(age!).toBeGreaterThanOrEqual(0);
+    expect(age!).toBeLessThan(1000);
+  });
+
+  it("setCached overwrites prior value", async () => {
+    const { setCached, getCached } = await freshCache();
+    setCached("k", "first");
+    setCached("k", "second");
+    expect(getCached("k")).toBe("second");
+  });
+});
+
+describe("cache persistence", () => {
+  it("setCached writes the store to disk as JSON", async () => {
+    const { setCached } = await freshCache();
+    const fs = await getFsMock();
+    setCached("k", { hello: "world" });
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    const written = fs.writeFileSync.mock.calls.at(-1)![1];
+    const parsed = JSON.parse(written);
+    expect(parsed.k.data).toEqual({ hello: "world" });
+    expect(typeof parsed.k.updatedAt).toBe("string");
+  });
+
+  it("loadCache reads prior entries from disk", async () => {
+    const fs = await getFsMock();
+    // Discover the path cache.ts writes to, then seed it with known content.
+    const probe = await freshCache();
+    probe.setCached("probe", 0);
+    const path = fs.writeFileSync.mock.calls.at(-1)![0];
+
+    fs.__store.clear();
+    fs.__store.set(
+      path,
+      JSON.stringify({
+        foo: { data: "bar", updatedAt: new Date().toISOString() },
+      }),
+    );
+
+    const reloaded = await freshCache();
+    reloaded.loadCache();
+    expect(reloaded.getCached("foo")).toBe("bar");
+  });
+
+  it("loadCache is a no-op when no cache file exists", async () => {
+    const fs = await getFsMock();
+    const cache = await freshCache();
+    expect(() => cache.loadCache()).not.toThrow();
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+  });
+
+  it("loadCache tolerates malformed JSON without throwing", async () => {
+    const fs = await getFsMock();
+    const probe = await freshCache();
+    probe.setCached("probe", 0);
+    const path = fs.writeFileSync.mock.calls.at(-1)![0];
+
+    fs.__store.clear();
+    fs.__store.set(path, "{ not json");
+
+    const reloaded = await freshCache();
+    expect(() => reloaded.loadCache()).not.toThrow();
+    expect(reloaded.getCached("anything")).toBeNull();
+  });
+});
+
+describe("cache in DEMO mode", () => {
+  it("setCached skips writing to disk", async () => {
+    vi.stubEnv("DEMO", "1");
+    const { setCached } = await freshCache();
+    const fs = await getFsMock();
+    setCached("k", "v");
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+});

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FsMock } from "./test-utils/fs-mock.js";
+
+vi.mock("node:fs", async () => {
+  const { createFsMock } = await import("./test-utils/fs-mock.js");
+  return createFsMock();
+});
+
+vi.mock("@octokit/rest", async () => {
+  const { octokitStub } = await import("./test-utils/octokit-mock.js");
+  return { Octokit: octokitStub({ login: "alice" }) };
+});
+
+async function freshConfig() {
+  vi.resetModules();
+  return import("./config.js");
+}
+
+async function fsMock(): Promise<FsMock> {
+  return (await import("node:fs")) as unknown as FsMock;
+}
+
+beforeEach(async () => {
+  (await fsMock()).__store.clear();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("readConfig", () => {
+  it("returns null when no config file exists", async () => {
+    const { readConfig } = await freshConfig();
+    expect(readConfig()).toBeNull();
+  });
+
+  it("parses a valid YAML config", async () => {
+    const { readConfig, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(
+      CONFIG_PATH,
+      "github:\n  token: ghp_test\nport: 9000\n",
+    );
+    const config = readConfig();
+    expect(config?.github?.token).toBe("ghp_test");
+    expect(config?.port).toBe(9000);
+  });
+
+  it("returns null on invalid YAML rather than throwing", async () => {
+    const { readConfig, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(
+      CONFIG_PATH,
+      "github:\n  token: [unterminated",
+    );
+    expect(readConfig()).toBeNull();
+  });
+});
+
+describe("getPort", () => {
+  it("uses PORT env var when set", async () => {
+    vi.stubEnv("PORT", "9999");
+    const { getPort } = await freshConfig();
+    expect(getPort()).toBe(9999);
+  });
+
+  it("falls back to config.port when env missing", async () => {
+    const { getPort, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(CONFIG_PATH, "port: 8000\n");
+    expect(getPort()).toBe(8000);
+  });
+
+  it("defaults to 7100 when no config and no env", async () => {
+    const { getPort } = await freshConfig();
+    expect(getPort()).toBe(7100);
+  });
+});
+
+describe("resolveInstances", () => {
+  it("returns hardcoded fixtures in DEMO mode", async () => {
+    vi.stubEnv("DEMO", "1");
+    const { resolveInstances } = await freshConfig();
+    const instances = await resolveInstances();
+    expect(instances.map((i) => i.id)).toEqual(["github", "ghe"]);
+    expect(instances[0].username).toBe("octocat");
+  });
+
+  it("returns empty list when no config", async () => {
+    const { resolveInstances } = await freshConfig();
+    expect(await resolveInstances()).toEqual([]);
+  });
+
+  it("resolves github.com instance from config", async () => {
+    const { resolveInstances, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(CONFIG_PATH, "github:\n  token: ghp_test\n");
+    const instances = await resolveInstances();
+    expect(instances).toHaveLength(1);
+    expect(instances[0]).toMatchObject({
+      id: "github",
+      label: "github.com",
+      token: "ghp_test",
+      username: "alice",
+    });
+  });
+
+  it("resolves enterprise instance with custom label + baseUrl", async () => {
+    const { resolveInstances, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(
+      CONFIG_PATH,
+      "enterprise:\n  label: Work\n  baseUrl: https://ghe.example.com/api/v3\n  token: ghe_test\n",
+    );
+    const instances = await resolveInstances();
+    expect(instances).toHaveLength(1);
+    expect(instances[0]).toMatchObject({
+      id: "ghe",
+      label: "Work",
+      baseUrl: "https://ghe.example.com/api/v3",
+      token: "ghe_test",
+    });
+  });
+
+  it("falls back to label 'GHE' when not set", async () => {
+    const { resolveInstances, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(
+      CONFIG_PATH,
+      "enterprise:\n  baseUrl: https://ghe.example.com/api/v3\n  token: ghe_test\n",
+    );
+    const instances = await resolveInstances();
+    expect(instances[0].label).toBe("GHE");
+  });
+
+  it("skips enterprise when baseUrl missing", async () => {
+    const { resolveInstances, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(
+      CONFIG_PATH,
+      "enterprise:\n  token: ghe_test\n",
+    );
+    const instances = await resolveInstances();
+    expect(instances).toEqual([]);
+  });
+
+  it("resolves both instances when both configured", async () => {
+    const { resolveInstances, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(
+      CONFIG_PATH,
+      "github:\n  token: ghp_test\nenterprise:\n  baseUrl: https://ghe.example.com/api/v3\n  token: ghe_test\n",
+    );
+    const instances = await resolveInstances();
+    expect(instances.map((i) => i.id)).toEqual(["github", "ghe"]);
+  });
+});
+
+describe("getInstances caching", () => {
+  it("memoizes after the first resolve", async () => {
+    const { getInstances, resolveInstances, CONFIG_PATH } = await freshConfig();
+    (await fsMock()).__store.set(CONFIG_PATH, "github:\n  token: ghp_test\n");
+
+    await resolveInstances();
+    // Remove the config — cached value should still return
+    (await fsMock()).__store.clear();
+
+    const again = await getInstances();
+    expect(again).toHaveLength(1);
+    expect(again[0].token).toBe("ghp_test");
+  });
+});

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOctokit } = vi.hoisted(() => ({
+  mockOctokit: {
+    search: { issuesAndPullRequests: vi.fn() },
+    pulls: { get: vi.fn(), listReviews: vi.fn() },
+    checks: { listForRef: vi.fn() },
+    repos: { getCombinedStatusForRef: vi.fn() },
+    activity: { listNotificationsForAuthenticatedUser: vi.fn() },
+    graphql: vi.fn(),
+  },
+}));
+
+vi.mock("./github-client.js", () => ({
+  getClient: async () => mockOctokit,
+  getInstance: async (id: string) => ({
+    id,
+    label: id,
+    baseUrl: "",
+    token: "t",
+    username: "alice",
+  }),
+}));
+
+const { fetchPrs, fetchNotifications, fetchRecentPrs } = await import(
+  "./fetchers.js"
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Safe defaults
+  mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] });
+  mockOctokit.pulls.get.mockResolvedValue({
+    data: {
+      body: "",
+      head: { ref: "feat" },
+      base: { ref: "main" },
+      additions: 0,
+      deletions: 0,
+      commits: 0,
+      comments: 0,
+      review_comments: 0,
+      mergeable: true,
+    },
+  });
+  mockOctokit.checks.listForRef.mockResolvedValue({
+    data: { check_runs: [{ status: "completed", conclusion: "success" }] },
+  });
+  mockOctokit.repos.getCombinedStatusForRef.mockResolvedValue({
+    data: { statuses: [] },
+  });
+  mockOctokit.graphql.mockResolvedValue({});
+});
+
+function prSearchItem(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 1,
+    node_id: "PR_1",
+    number: 5,
+    title: "t",
+    html_url: "http://x",
+    repository_url: "https://api.github.com/repos/o/r",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    user: { login: "alice", avatar_url: "" },
+    draft: false,
+    labels: [{ name: "bug" }],
+    ...over,
+  };
+}
+
+describe("fetchPrs", () => {
+  it("queries authored open PRs and returns shaped results", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [prSearchItem()] },
+    });
+    const prs = await fetchPrs("github");
+    expect(mockOctokit.search.issuesAndPullRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "author:alice type:pr state:open",
+        sort: "updated",
+        order: "desc",
+      }),
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toMatchObject({
+      number: 5,
+      repo: "o/r",
+      author: "alice",
+      ciStatus: "success",
+      labels: ["bug"],
+    });
+  });
+
+  it("filters out PRs whose author doesn't match (defensive)", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          prSearchItem({ user: { login: "alice", avatar_url: "" } }),
+          prSearchItem({
+            id: 2,
+            node_id: "PR_2",
+            user: { login: "bot", avatar_url: "" },
+          }),
+        ],
+      },
+    });
+    const prs = await fetchPrs("github");
+    expect(prs.map((p) => p.author)).toEqual(["alice"]);
+  });
+
+  it("populates mergeQueue + autoMerge + reviewDecision from GraphQL", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [prSearchItem()] },
+    });
+    mockOctokit.graphql.mockResolvedValue({
+      pr0: {
+        id: "PR_1",
+        mergeQueueEntry: { id: "MQ_1" },
+        autoMergeRequest: { enabledAt: "x" },
+        reviewDecision: "APPROVED",
+      },
+    });
+    const prs = await fetchPrs("github");
+    expect(prs[0]).toMatchObject({
+      inMergeQueue: true,
+      autoMerge: true,
+      reviewDecision: "APPROVED",
+    });
+  });
+
+  it("swallows GraphQL errors and leaves merge-queue fields as defaults", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [prSearchItem()] },
+    });
+    mockOctokit.graphql.mockRejectedValue(new Error("graphql down"));
+    const prs = await fetchPrs("github");
+    expect(prs[0]).toMatchObject({
+      inMergeQueue: false,
+      autoMerge: false,
+      reviewDecision: null,
+    });
+  });
+
+  it("handles empty search results", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [] },
+    });
+    const prs = await fetchPrs("github");
+    expect(prs).toEqual([]);
+    expect(mockOctokit.graphql).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchRecentPrs", () => {
+  it("queries closed PRs from the last week", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [] },
+    });
+    await fetchRecentPrs("github");
+    const q = mockOctokit.search.issuesAndPullRequests.mock.calls[0][0].q;
+    expect(q).toContain("author:alice");
+    expect(q).toContain("state:closed");
+    expect(q).toMatch(/closed:>=\d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe("fetchNotifications", () => {
+  it("omits review_requested notifications", async () => {
+    mockOctokit.activity.listNotificationsForAuthenticatedUser.mockResolvedValue(
+      {
+        data: [
+          {
+            id: "1",
+            subject: { title: "x", type: "PullRequest", url: "http://x" },
+            reason: "mention",
+            repository: { full_name: "o/r" },
+            updated_at: "2026-01-01T00:00:00Z",
+            unread: true,
+          },
+          {
+            id: "2",
+            subject: { title: "y", type: "PullRequest", url: "http://y" },
+            reason: "review_requested",
+            repository: { full_name: "o/r" },
+            updated_at: "2026-01-02T00:00:00Z",
+            unread: true,
+          },
+        ],
+      },
+    );
+    const notifs = await fetchNotifications("github");
+    expect(notifs.map((n) => n.id)).toEqual(["1"]);
+  });
+
+  it("shapes the payload for the UI", async () => {
+    mockOctokit.activity.listNotificationsForAuthenticatedUser.mockResolvedValue(
+      {
+        data: [
+          {
+            id: "1",
+            subject: { title: "hello", type: "Issue", url: "http://x" },
+            reason: "mention",
+            repository: { full_name: "o/r" },
+            updated_at: "2026-01-01T00:00:00Z",
+            unread: false,
+          },
+        ],
+      },
+    );
+    const [n] = await fetchNotifications("github");
+    expect(n).toEqual({
+      id: "1",
+      title: "hello",
+      type: "Issue",
+      reason: "mention",
+      repo: "o/r",
+      updatedAt: "2026-01-01T00:00:00Z",
+      unread: false,
+      url: "http://x",
+    });
+  });
+});

--- a/packages/server/src/fetchers.test.ts
+++ b/packages/server/src/fetchers.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { getCiStatus, summarizeReviews } from "./fetchers.js";
+
+describe("summarizeReviews", () => {
+  it("returns empty arrays when no reviews", () => {
+    expect(summarizeReviews([])).toEqual({
+      approved: [],
+      changesRequested: [],
+    });
+  });
+
+  it("collects approvers and change-requesters", () => {
+    const result = summarizeReviews([
+      { state: "APPROVED", user: { login: "alice" } },
+      { state: "CHANGES_REQUESTED", user: { login: "bob" } },
+    ]);
+    expect(result.approved).toEqual(["alice"]);
+    expect(result.changesRequested).toEqual(["bob"]);
+  });
+
+  it("keeps only each reviewer's latest non-comment state", () => {
+    const result = summarizeReviews([
+      { state: "CHANGES_REQUESTED", user: { login: "alice" } },
+      { state: "APPROVED", user: { login: "alice" } },
+    ]);
+    expect(result.approved).toEqual(["alice"]);
+    expect(result.changesRequested).toEqual([]);
+  });
+
+  it("ignores COMMENTED reviews so they don't overwrite approval", () => {
+    const result = summarizeReviews([
+      { state: "APPROVED", user: { login: "alice" } },
+      { state: "COMMENTED", user: { login: "alice" } },
+    ]);
+    expect(result.approved).toEqual(["alice"]);
+  });
+
+  it("skips reviews with no user", () => {
+    const result = summarizeReviews([{ state: "APPROVED", user: null }]);
+    expect(result.approved).toEqual([]);
+  });
+
+  it("dismissed review removes approval", () => {
+    const result = summarizeReviews([
+      { state: "APPROVED", user: { login: "alice" } },
+      { state: "DISMISSED", user: { login: "alice" } },
+    ]);
+    expect(result.approved).toEqual([]);
+    expect(result.changesRequested).toEqual([]);
+  });
+});
+
+function mockClient(overrides: {
+  statuses?: { state: string }[];
+  checks?: { status: string; conclusion: string | null }[];
+  statusesError?: boolean;
+  checksError?: boolean;
+}) {
+  return {
+    repos: {
+      getCombinedStatusForRef: vi.fn(() =>
+        overrides.statusesError
+          ? Promise.reject(new Error("boom"))
+          : Promise.resolve({ data: { statuses: overrides.statuses ?? [] } }),
+      ),
+    },
+    checks: {
+      listForRef: vi.fn(() =>
+        overrides.checksError
+          ? Promise.reject(new Error("boom"))
+          : Promise.resolve({ data: { check_runs: overrides.checks ?? [] } }),
+      ),
+    },
+    // biome-ignore lint: test mock — we intentionally type it as any
+  } as any;
+}
+
+describe("getCiStatus", () => {
+  it("returns 'unknown' when neither statuses nor checks exist", async () => {
+    const result = await getCiStatus(mockClient({}), "o", "r", "ref");
+    expect(result).toBe("unknown");
+  });
+
+  it("returns 'pending' when any check run is not completed", async () => {
+    const result = await getCiStatus(
+      mockClient({
+        checks: [
+          { status: "in_progress", conclusion: null },
+          { status: "completed", conclusion: "success" },
+        ],
+      }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("pending");
+  });
+
+  it("returns 'failure' on failed legacy status", async () => {
+    const result = await getCiStatus(
+      mockClient({ statuses: [{ state: "failure" }] }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("failure");
+  });
+
+  it("returns 'failure' on errored legacy status", async () => {
+    const result = await getCiStatus(
+      mockClient({ statuses: [{ state: "error" }] }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("failure");
+  });
+
+  it.each(["failure", "timed_out", "cancelled"])(
+    "returns 'failure' when a completed check has conclusion %s",
+    async (conclusion) => {
+      const result = await getCiStatus(
+        mockClient({ checks: [{ status: "completed", conclusion }] }),
+        "o",
+        "r",
+        "ref",
+      );
+      expect(result).toBe("failure");
+    },
+  );
+
+  it("returns 'success' when everything completed successfully", async () => {
+    const result = await getCiStatus(
+      mockClient({
+        statuses: [{ state: "success" }],
+        checks: [{ status: "completed", conclusion: "success" }],
+      }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("success");
+  });
+
+  it("tolerates both API calls failing (returns 'unknown')", async () => {
+    const result = await getCiStatus(
+      mockClient({ statusesError: true, checksError: true }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("unknown");
+  });
+});

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -9,7 +9,7 @@ interface MergeQueueInfo {
   reviewDecision: string | null;
 }
 
-async function fetchMergeQueueStatus(
+export async function fetchMergeQueueStatus(
   client: Octokit,
   items: { node_id: string }[],
 ): Promise<Map<string, MergeQueueInfo>> {
@@ -49,7 +49,7 @@ async function fetchMergeQueueStatus(
   return result;
 }
 
-async function getCiStatus(
+export async function getCiStatus(
   client: Octokit,
   owner: string,
   repo: string,
@@ -90,7 +90,7 @@ async function getCiStatus(
   return "success";
 }
 
-function summarizeReviews(reviews: Review[]) {
+export function summarizeReviews(reviews: Review[]) {
   const latest = new Map<string, string>();
   for (const r of reviews) {
     if (!r.user) continue;

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { maskToken } from "./routes.js";
 
 const { cacheStore, configStub, fetchersStub, mockOctokit, octokitHolder } =
   vi.hoisted(() => {
@@ -76,7 +75,7 @@ vi.mock("@octokit/rest", async () => {
 });
 
 // Import after mocks are registered
-const { api } = await import("./routes.js");
+const { api, maskToken } = await import("./routes.js");
 
 function call(
   path: string,

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -1,0 +1,522 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { maskToken } from "./routes.js";
+
+const { cacheStore, configStub, fetchersStub, mockOctokit, octokitHolder } =
+  vi.hoisted(() => {
+    return {
+      cacheStore: new Map<string, unknown>(),
+      configStub: {
+        configExists: vi.fn(),
+        readConfig: vi.fn(),
+        writeConfig: vi.fn(),
+        resolveInstances: vi.fn(),
+        getInstances: vi.fn(),
+      },
+      fetchersStub: {
+        fetchPrs: vi.fn(),
+        fetchRecentPrs: vi.fn(),
+        fetchReviews: vi.fn(),
+        fetchNotifications: vi.fn(),
+      },
+      mockOctokit: {
+        users: { getAuthenticated: vi.fn() },
+        activity: { markThreadAsDone: vi.fn() },
+        pulls: {
+          createReview: vi.fn(),
+          get: vi.fn(),
+          update: vi.fn(),
+          listFiles: vi.fn(),
+          listCommits: vi.fn(),
+          listReviewComments: vi.fn(),
+        },
+        issues: { listComments: vi.fn(), createComment: vi.fn() },
+        checks: { listForRef: vi.fn() },
+        repos: { getCombinedStatusForRef: vi.fn() },
+        actions: {
+          listWorkflowRunsForRepo: vi.fn(),
+          reRunWorkflow: vi.fn(),
+        },
+        search: { issuesAndPullRequests: vi.fn() },
+        graphql: vi.fn(),
+      },
+      octokitHolder: { ctor: null as unknown },
+    };
+  });
+
+vi.mock("./cache.js", () => ({
+  getCached: (key: string) => cacheStore.get(key) ?? null,
+  setCached: (key: string, data: unknown) => {
+    cacheStore.set(key, data);
+  },
+}));
+
+vi.mock("./config.js", () => configStub);
+vi.mock("./fetchers.js", () => fetchersStub);
+
+vi.mock("./github-client.js", () => ({
+  getClient: async () => mockOctokit,
+  getInstance: async (id: string) => ({
+    id,
+    label: id,
+    baseUrl: "https://api.github.com",
+    token: "t",
+    username: "alice",
+  }),
+  clearClients: () => {},
+}));
+
+vi.mock("@octokit/rest", async () => {
+  const { octokitStub } = await import("./test-utils/octokit-mock.js");
+  octokitHolder.ctor = octokitStub({ login: "alice" });
+  return {
+    get Octokit() {
+      return octokitHolder.ctor;
+    },
+  };
+});
+
+// Import after mocks are registered
+const { api } = await import("./routes.js");
+
+function call(
+  path: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> },
+) {
+  return api.request(path, {
+    method: init?.method,
+    headers: { "content-type": "application/json", ...init?.headers },
+    body: init?.body == null ? undefined : JSON.stringify(init.body),
+  });
+}
+
+beforeEach(() => {
+  cacheStore.clear();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("maskToken", () => {
+  it("masks long tokens keeping the last 4 chars", () => {
+    expect(maskToken("ghp_abcdefghij")).toBe("****ghij");
+  });
+
+  it("fully masks tokens of 4 chars or less", () => {
+    expect(maskToken("abcd")).toBe("****");
+    expect(maskToken("abc")).toBe("****");
+    expect(maskToken("")).toBe("****");
+  });
+});
+
+describe("GET /config", () => {
+  it("returns DEMO shape when DEMO=1", async () => {
+    vi.stubEnv("DEMO", "1");
+    const res = await call("/config");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.exists).toBe(true);
+    expect(body.config.github.token).toMatch(/^\*+/);
+  });
+
+  it("returns exists:false when config missing", async () => {
+    configStub.configExists.mockReturnValue(false);
+    const res = await call("/config");
+    const body = await res.json();
+    expect(body).toEqual({ exists: false });
+  });
+
+  it("masks github + enterprise tokens", async () => {
+    configStub.configExists.mockReturnValue(true);
+    configStub.readConfig.mockReturnValue({
+      github: { token: "ghp_secretvalue" },
+      enterprise: {
+        label: "Work",
+        baseUrl: "https://ghe.example.com/api/v3",
+        token: "ghe_secretvalue",
+      },
+      port: 7100,
+    });
+    const res = await call("/config");
+    const body = await res.json();
+    expect(body.config.github.token).toBe("****alue");
+    expect(body.config.enterprise.token).toBe("****alue");
+    expect(body.config.enterprise.baseUrl).toBe(
+      "https://ghe.example.com/api/v3",
+    );
+  });
+});
+
+describe("PUT /config", () => {
+  it("rejects with 422 when github token is invalid", async () => {
+    const { octokitStub } = await import("./test-utils/octokit-mock.js");
+    const original = octokitHolder.ctor;
+    octokitHolder.ctor = octokitStub({ throws: new Error("401") });
+    configStub.readConfig.mockReturnValue(null);
+    const res = await call("/config", {
+      method: "PUT",
+      body: { github: { token: "bad" } },
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.errors).toContain("GitHub.com token is invalid");
+    expect(configStub.writeConfig).not.toHaveBeenCalled();
+    octokitHolder.ctor = original;
+  });
+
+  it("preserves existing token when incoming is empty string", async () => {
+    configStub.readConfig.mockReturnValue({ github: { token: "existing" } });
+    configStub.resolveInstances.mockResolvedValue([]);
+    const res = await call("/config", {
+      method: "PUT",
+      body: { github: { token: "" } },
+    });
+    expect(res.status).toBe(200);
+    expect(configStub.writeConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        github: expect.objectContaining({ token: "existing" }),
+      }),
+    );
+  });
+
+  it("clears cached data after successful save", async () => {
+    configStub.readConfig.mockReturnValue(null);
+    configStub.resolveInstances.mockResolvedValue([
+      {
+        id: "github",
+        label: "gh",
+        baseUrl: "",
+        token: "t",
+        username: "alice",
+      },
+    ]);
+    cacheStore.set("github:prs", [{ id: 1 }]);
+    await call("/config", {
+      method: "PUT",
+      body: {},
+    });
+    expect(cacheStore.get("github:prs")).toBeNull();
+    expect(cacheStore.get("github:reviews")).toBeNull();
+    expect(cacheStore.get("github:notifications")).toBeNull();
+  });
+});
+
+describe("GET /instances", () => {
+  it("returns id/label/username without exposing tokens", async () => {
+    configStub.getInstances.mockResolvedValue([
+      {
+        id: "github",
+        label: "gh",
+        baseUrl: "",
+        token: "SECRET",
+        username: "alice",
+      },
+    ]);
+    const res = await call("/instances");
+    const body = await res.json();
+    expect(body).toEqual([{ id: "github", label: "gh", username: "alice" }]);
+    expect(JSON.stringify(body)).not.toContain("SECRET");
+  });
+});
+
+describe("caching behavior on GET /:instanceId/prs", () => {
+  it("returns cached data without calling the fetcher", async () => {
+    cacheStore.set("github:prs", [{ cached: true }]);
+    const res = await call("/github/prs");
+    const body = await res.json();
+    expect(body).toEqual([{ cached: true }]);
+    expect(fetchersStub.fetchPrs).not.toHaveBeenCalled();
+  });
+
+  it("calls fetcher and caches the result when cache is empty", async () => {
+    fetchersStub.fetchPrs.mockResolvedValue([{ fresh: true }]);
+    const res = await call("/github/prs");
+    const body = await res.json();
+    expect(body).toEqual([{ fresh: true }]);
+    expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
+    expect(cacheStore.get("github:prs")).toEqual([{ fresh: true }]);
+  });
+
+  it("?fresh=1 bypasses cache even when populated", async () => {
+    cacheStore.set("github:prs", [{ stale: true }]);
+    fetchersStub.fetchPrs.mockResolvedValue([{ fresh: true }]);
+    const res = await call("/github/prs?fresh=1");
+    const body = await res.json();
+    expect(body).toEqual([{ fresh: true }]);
+    expect(fetchersStub.fetchPrs).toHaveBeenCalledOnce();
+  });
+});
+
+describe("DELETE /:instanceId/notifications/:threadId", () => {
+  it("calls markThreadAsDone and removes the thread from cache", async () => {
+    cacheStore.set("github:notifications", [{ id: "42" }, { id: "99" }]);
+    mockOctokit.activity.markThreadAsDone.mockResolvedValue({});
+    const res = await call("/github/notifications/42", { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect(mockOctokit.activity.markThreadAsDone).toHaveBeenCalledWith({
+      thread_id: 42,
+    });
+    expect(cacheStore.get("github:notifications")).toEqual([{ id: "99" }]);
+  });
+});
+
+describe("POST /:instanceId/prs/:owner/:repo/:prNumber/approve", () => {
+  it("creates an APPROVE review and invalidates prs + reviews caches", async () => {
+    cacheStore.set("github:prs", [{ id: 1 }]);
+    cacheStore.set("github:reviews", [{ id: 2 }]);
+    mockOctokit.pulls.createReview.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/approve", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(mockOctokit.pulls.createReview).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      pull_number: 5,
+      event: "APPROVE",
+    });
+    expect(cacheStore.get("github:prs")).toBeNull();
+    expect(cacheStore.get("github:reviews")).toBeNull();
+  });
+});
+
+describe("POST /:instanceId/prs/:owner/:repo/:prNumber/auto-merge", () => {
+  it("enables auto-merge when currently off and returns new state", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { auto_merge: null, node_id: "PR_123" },
+    });
+    mockOctokit.graphql.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/auto-merge", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, autoMerge: true });
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("enablePullRequestAutoMerge"),
+      { id: "PR_123" },
+    );
+  });
+
+  it("disables auto-merge when currently on", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { auto_merge: { enabled_at: "x" }, node_id: "PR_123" },
+    });
+    mockOctokit.graphql.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/auto-merge", { method: "POST" });
+    expect(await res.json()).toEqual({ ok: true, autoMerge: false });
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("disableAutoMerge"),
+      { id: "PR_123" },
+    );
+  });
+});
+
+describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
+  it("sets state=closed and invalidates prs + reviews caches", async () => {
+    cacheStore.set("github:prs", [{ id: 1 }]);
+    cacheStore.set("github:reviews", [{ id: 2 }]);
+    mockOctokit.pulls.update.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/close", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(mockOctokit.pulls.update).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      pull_number: 5,
+      state: "closed",
+    });
+    expect(cacheStore.get("github:prs")).toBeNull();
+    expect(cacheStore.get("github:reviews")).toBeNull();
+  });
+});
+
+describe("PATCH /:instanceId/prs/:owner/:repo/:prNumber", () => {
+  it("400s when title is missing", async () => {
+    const res = await call("/github/prs/o/r/5", { method: "PATCH", body: {} });
+    expect(res.status).toBe(400);
+    expect(mockOctokit.pulls.update).not.toHaveBeenCalled();
+  });
+
+  it("400s on invalid JSON body", async () => {
+    const res = await api.request("/github/prs/o/r/5", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("updates title and invalidates prs cache", async () => {
+    cacheStore.set("github:prs", [{ id: 1 }]);
+    mockOctokit.pulls.update.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5", {
+      method: "PATCH",
+      body: { title: "new title" },
+    });
+    expect(res.status).toBe(200);
+    expect(mockOctokit.pulls.update).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      pull_number: 5,
+      title: "new title",
+    });
+    expect(cacheStore.get("github:prs")).toBeNull();
+  });
+});
+
+describe("POST /:instanceId/prs/:owner/:repo/:prNumber/toggle-draft", () => {
+  it("marks a draft PR as ready for review", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { draft: true, node_id: "PR_1" },
+    });
+    mockOctokit.graphql.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/toggle-draft", {
+      method: "POST",
+    });
+    expect(await res.json()).toEqual({ ok: true, draft: false });
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("markPullRequestReadyForReview"),
+      { id: "PR_1" },
+    );
+  });
+
+  it("converts a ready PR to draft", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { draft: false, node_id: "PR_1" },
+    });
+    mockOctokit.graphql.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/toggle-draft", {
+      method: "POST",
+    });
+    expect(await res.json()).toEqual({ ok: true, draft: true });
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("convertPullRequestToDraft"),
+      { id: "PR_1" },
+    );
+  });
+});
+
+describe("POST /:instanceId/prs/:owner/:repo/:prNumber/rerun-ci", () => {
+  it("404s when no workflow runs are found", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { head: { sha: "abc" }, node_id: "PR_1" },
+    });
+    mockOctokit.actions.listWorkflowRunsForRepo.mockResolvedValue({
+      data: { workflow_runs: [] },
+    });
+    const res = await call("/github/prs/o/r/5/rerun-ci", { method: "POST" });
+    expect(res.status).toBe(404);
+    expect(mockOctokit.actions.reRunWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("reruns the latest workflow run", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { head: { sha: "abc" }, node_id: "PR_1" },
+    });
+    mockOctokit.actions.listWorkflowRunsForRepo.mockResolvedValue({
+      data: { workflow_runs: [{ id: 777 }] },
+    });
+    mockOctokit.actions.reRunWorkflow.mockResolvedValue({});
+    const res = await call("/github/prs/o/r/5/rerun-ci", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(mockOctokit.actions.reRunWorkflow).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      run_id: 777,
+    });
+  });
+});
+
+describe("GET /:instanceId/prs/:owner/:repo/:prNumber/meta", () => {
+  it("merges legacy statuses + checks into a unified list", async () => {
+    mockOctokit.pulls.listFiles.mockResolvedValue({
+      data: [
+        {
+          filename: "a.ts",
+          additions: 1,
+          deletions: 2,
+          status: "modified",
+          patch: "+x",
+        },
+      ],
+    });
+    mockOctokit.pulls.listCommits.mockResolvedValue({
+      data: [{ sha: "abcdef1234", commit: { message: "feat: x\n\nbody" } }],
+    });
+    mockOctokit.checks.listForRef.mockResolvedValue({
+      data: {
+        check_runs: [
+          { name: "build", status: "completed", conclusion: "success" },
+        ],
+      },
+    });
+    mockOctokit.repos.getCombinedStatusForRef.mockResolvedValue({
+      data: {
+        statuses: [
+          { context: "ci/old", state: "failure" },
+          { context: "build", state: "success" },
+        ],
+      },
+    });
+    const res = await call("/github/prs/o/r/5/meta");
+    const body = await res.json();
+    expect(body.files).toEqual([
+      {
+        filename: "a.ts",
+        additions: 1,
+        deletions: 2,
+        status: "modified",
+        patch: "+x",
+      },
+    ]);
+    expect(body.commits).toEqual([{ sha: "abcdef1", message: "feat: x" }]);
+    // check-run takes precedence over same-named status (Map overwrite order)
+    const buildCheck = body.checks.find(
+      (c: { name: string }) => c.name === "build",
+    );
+    expect(buildCheck.conclusion).toBe("success");
+    const oldCheck = body.checks.find(
+      (c: { name: string }) => c.name === "ci/old",
+    );
+    expect(oldCheck.conclusion).toBe("failure");
+  });
+});
+
+describe("GET /:instanceId/prs/:owner/:repo/:prNumber/comments", () => {
+  it("merges issue + review comments sorted by createdAt", async () => {
+    mockOctokit.issues.listComments.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          user: { login: "alice" },
+          body: "first",
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+    mockOctokit.pulls.listReviewComments.mockResolvedValue({
+      data: [
+        {
+          id: 2,
+          user: { login: "bob" },
+          body: "on file",
+          created_at: "2026-01-02T00:00:00Z",
+          path: "a.ts",
+        },
+      ],
+    });
+    const res = await call("/github/prs/o/r/5/comments");
+    const body = await res.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].id).toBe(1);
+    expect(body[0].path).toBeNull();
+    expect(body[1].path).toBe("a.ts");
+  });
+});
+
+describe("GET /:instanceId/search/prs", () => {
+  it("scopes the search query to the authenticated user's closed PRs", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [] },
+    });
+    await call("/github/search/prs?q=feature");
+    const call0 = mockOctokit.search.issuesAndPullRequests.mock.calls[0][0];
+    expect(call0.q).toContain("author:alice");
+    expect(call0.q).toContain("type:pr");
+    expect(call0.q).toContain("state:closed");
+    expect(call0.q).toContain("feature");
+  });
+});

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -34,7 +34,7 @@ async function cachedOrFetch<T>(
   return data;
 }
 
-function maskToken(token: string): string {
+export function maskToken(token: string): string {
   if (token.length <= 4) return "****";
   return "****" + token.slice(-4);
 }

--- a/packages/server/src/test-utils/fs-mock.ts
+++ b/packages/server/src/test-utils/fs-mock.ts
@@ -1,0 +1,26 @@
+import { vi } from "vitest";
+
+export interface FsMock {
+  existsSync: ReturnType<typeof vi.fn>;
+  readFileSync: ReturnType<typeof vi.fn>;
+  writeFileSync: ReturnType<typeof vi.fn>;
+  mkdirSync: ReturnType<typeof vi.fn>;
+  __store: Map<string, string>;
+}
+
+export function createFsMock(): FsMock {
+  const store = new Map<string, string>();
+  return {
+    existsSync: vi.fn((path: string) => store.has(path)),
+    readFileSync: vi.fn((path: string) => {
+      const v = store.get(path);
+      if (v == null) throw new Error("ENOENT");
+      return v;
+    }),
+    writeFileSync: vi.fn((path: string, data: string) => {
+      store.set(path, data);
+    }),
+    mkdirSync: vi.fn(),
+    __store: store,
+  };
+}

--- a/packages/server/src/test-utils/octokit-mock.ts
+++ b/packages/server/src/test-utils/octokit-mock.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal Octokit stub used when code-under-test calls `new Octokit(...)`
+ * directly (e.g. the PUT /config token validation path).
+ */
+export function octokitStub(
+  opts: { login?: string; throws?: Error } = {},
+): new (
+  args?: unknown,
+) => { users: { getAuthenticated: () => Promise<unknown> } } {
+  const login = opts.login ?? "alice";
+  return class {
+    users = {
+      getAuthenticated: async () => {
+        if (opts.throws) throw opts.throws;
+        return { data: { login } };
+      },
+    };
+  };
+}
+
+/**
+ * Holder that lets tests swap the Octokit constructor at runtime.
+ * Use with `vi.mock("@octokit/rest", () => ({ get Octokit() { return holder.ctor; } }))`.
+ */
+export interface OctokitHolder {
+  ctor: ReturnType<typeof octokitStub>;
+}
+
+export function createOctokitHolder(
+  initial: ReturnType<typeof octokitStub> = octokitStub(),
+): OctokitHolder {
+  return { ctor: initial };
+}

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       tsx:
         specifier: ^4.19.3
         version: 4.21.0
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/web:
     dependencies:


### PR DESCRIPTION
## Summary
Adds vitest to the server package and 74 unit/integration tests across 5 files.

**Coverage:**
- `cache.test.ts` (10) — roundtrip, age, persistence via mocked `node:fs`, malformed JSON tolerance, DEMO skip
- `config.test.ts` (14) — YAML parse, port precedence, DEMO fixtures, single/dual/enterprise resolution, memoization
- `fetchers.test.ts` (15) — `summarizeReviews` edge cases; `getCiStatus` full matrix
- `fetchers.integration.test.ts` (8) — `fetchPrs` query shape + author filter + merge-queue GraphQL, `fetchRecentPrs` date window, `fetchNotifications` reason filter
- `routes.test.ts` (27) — `maskToken`; GET/PUT `/config` (masking, token validation, empty-token preservation, cache clear); `/instances` token redaction; cache hit/miss/`?fresh=1`; approve/close/auto-merge/toggle-draft/rerun-ci; PATCH title validation; notification DELETE optimistic update; meta merge ordering; comments sort; search query scoping

**Structure:**
- Exposed previously-private helpers (`summarizeReviews`, `getCiStatus`, `fetchMergeQueueStatus`, `maskToken`) as test seams.
- Shared mocks under `packages/server/src/test-utils/` (`fs-mock.ts`, `octokit-mock.ts`).
- Server test suite runs in ~0.3s; full workspace (`pnpm test`) runs server + web in parallel.

## Test plan
- [x] `pnpm test` — 78 passing (74 server + 4 web)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm fmt:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)