### PR TITLE
resync from server after mutations

### DIFF
--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -76,6 +76,7 @@ vi.mock("@octokit/rest", async () => {
 
 // Import after mocks are registered
 const { api, maskToken } = await import("./routes.js");
+const { waitForPendingResyncs } = await import("./sync.js");
 
 function call(
   path: string,
@@ -88,7 +89,8 @@ function call(
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await waitForPendingResyncs();
   cacheStore.clear();
   vi.clearAllMocks();
   vi.unstubAllEnvs();
@@ -245,22 +247,27 @@ describe("caching behavior on GET /:instanceId/prs", () => {
 });
 
 describe("DELETE /:instanceId/notifications/:threadId", () => {
-  it("calls markThreadAsDone and removes the thread from cache", async () => {
+  it("calls markThreadAsDone, optimistically updates cache, and resyncs", async () => {
     cacheStore.set("github:notifications", [{ id: "42" }, { id: "99" }]);
+    fetchersStub.fetchNotifications.mockResolvedValue([{ id: "99" }]);
     mockOctokit.activity.markThreadAsDone.mockResolvedValue({});
     const res = await call("/github/notifications/42", { method: "DELETE" });
     expect(res.status).toBe(200);
     expect(mockOctokit.activity.markThreadAsDone).toHaveBeenCalledWith({
       thread_id: 42,
     });
+    await waitForPendingResyncs();
+    expect(fetchersStub.fetchNotifications).toHaveBeenCalledWith("github");
     expect(cacheStore.get("github:notifications")).toEqual([{ id: "99" }]);
   });
 });
 
 describe("POST /:instanceId/prs/:owner/:repo/:prNumber/approve", () => {
-  it("creates an APPROVE review and invalidates prs + reviews caches", async () => {
+  it("creates an APPROVE review and resyncs prs + reviews", async () => {
     cacheStore.set("github:prs", [{ id: 1 }]);
     cacheStore.set("github:reviews", [{ id: 2 }]);
+    fetchersStub.fetchPrs.mockResolvedValue([{ id: 1, approved: true }]);
+    fetchersStub.fetchReviews.mockResolvedValue([]);
     mockOctokit.pulls.createReview.mockResolvedValue({});
     const res = await call("/github/prs/o/r/5/approve", { method: "POST" });
     expect(res.status).toBe(200);
@@ -270,8 +277,11 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/approve", () => {
       pull_number: 5,
       event: "APPROVE",
     });
-    expect(cacheStore.get("github:prs")).toBeNull();
-    expect(cacheStore.get("github:reviews")).toBeNull();
+    await waitForPendingResyncs();
+    expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
+    expect(fetchersStub.fetchReviews).toHaveBeenCalledWith("github");
+    expect(cacheStore.get("github:prs")).toEqual([{ id: 1, approved: true }]);
+    expect(cacheStore.get("github:reviews")).toEqual([]);
   });
 });
 
@@ -305,9 +315,12 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/auto-merge", () => {
 });
 
 describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
-  it("sets state=closed and invalidates prs + reviews caches", async () => {
+  it("sets state=closed and resyncs prs, reviews, recent-prs", async () => {
     cacheStore.set("github:prs", [{ id: 1 }]);
     cacheStore.set("github:reviews", [{ id: 2 }]);
+    fetchersStub.fetchPrs.mockResolvedValue([]);
+    fetchersStub.fetchReviews.mockResolvedValue([]);
+    fetchersStub.fetchRecentPrs.mockResolvedValue([{ id: 5, state: "closed" }]);
     mockOctokit.pulls.update.mockResolvedValue({});
     const res = await call("/github/prs/o/r/5/close", { method: "POST" });
     expect(res.status).toBe(200);
@@ -317,8 +330,10 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
       pull_number: 5,
       state: "closed",
     });
-    expect(cacheStore.get("github:prs")).toBeNull();
-    expect(cacheStore.get("github:reviews")).toBeNull();
+    await waitForPendingResyncs();
+    expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
+    expect(fetchersStub.fetchReviews).toHaveBeenCalledWith("github");
+    expect(fetchersStub.fetchRecentPrs).toHaveBeenCalledWith("github");
   });
 });
 
@@ -338,8 +353,9 @@ describe("PATCH /:instanceId/prs/:owner/:repo/:prNumber", () => {
     expect(res.status).toBe(400);
   });
 
-  it("updates title and invalidates prs cache", async () => {
+  it("updates title and resyncs prs", async () => {
     cacheStore.set("github:prs", [{ id: 1 }]);
+    fetchersStub.fetchPrs.mockResolvedValue([{ id: 1, title: "new title" }]);
     mockOctokit.pulls.update.mockResolvedValue({});
     const res = await call("/github/prs/o/r/5", {
       method: "PATCH",
@@ -352,7 +368,11 @@ describe("PATCH /:instanceId/prs/:owner/:repo/:prNumber", () => {
       pull_number: 5,
       title: "new title",
     });
-    expect(cacheStore.get("github:prs")).toBeNull();
+    await waitForPendingResyncs();
+    expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
+    expect(cacheStore.get("github:prs")).toEqual([
+      { id: 1, title: "new title" },
+    ]);
   });
 });
 

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -16,6 +16,7 @@ import {
   fetchReviews,
 } from "./fetchers.js";
 import { clearClients, getClient, getInstance } from "./github-client.js";
+import { scheduleResync } from "./sync.js";
 
 const api = new Hono();
 
@@ -213,6 +214,8 @@ api.delete("/:instanceId/notifications/:threadId", async (c) => {
     );
   }
 
+  scheduleResync(instanceId, ["notifications"]);
+
   return c.json({ ok: true });
 });
 
@@ -228,9 +231,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/approve", async (c) => {
     event: "APPROVE",
   });
 
-  // Invalidate caches so next request fetches fresh
-  setCached(`${instanceId}:prs`, null);
-  setCached(`${instanceId}:reviews`, null);
+  scheduleResync(instanceId, ["prs", "reviews"]);
 
   return c.json({ ok: true });
 });
@@ -261,7 +262,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/auto-merge", async (c) => {
     );
   }
 
-  setCached(`${instanceId}:prs`, null);
+  scheduleResync(instanceId, ["prs"]);
 
   return c.json({ ok: true, autoMerge: !pr.auto_merge });
 });
@@ -278,8 +279,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/close", async (c) => {
     state: "closed",
   });
 
-  setCached(`${instanceId}:prs`, null);
-  setCached(`${instanceId}:reviews`, null);
+  scheduleResync(instanceId, ["prs", "reviews", "recent-prs"]);
 
   return c.json({ ok: true });
 });
@@ -302,7 +302,7 @@ api.patch("/:instanceId/prs/:owner/:repo/:prNumber", async (c) => {
     title,
   });
 
-  setCached(`${instanceId}:prs`, null);
+  scheduleResync(instanceId, ["prs"]);
 
   return c.json({ ok: true, title });
 });
@@ -326,7 +326,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/toggle-draft", async (c) => {
 
   await client.graphql(mutation, { id: pr.node_id });
 
-  setCached(`${instanceId}:prs`, null);
+  scheduleResync(instanceId, ["prs"]);
 
   return c.json({ ok: true, draft: !pr.draft });
 });
@@ -359,6 +359,8 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/rerun-ci", async (c) => {
   }
 
   await client.actions.reRunWorkflow({ owner, repo, run_id: latestRun.id });
+
+  scheduleResync(instanceId, ["prs"]);
 
   return c.json({ ok: true });
 });

--- a/packages/server/src/sync.ts
+++ b/packages/server/src/sync.ts
@@ -9,27 +9,57 @@ import {
 
 const SYNC_INTERVAL = 30_000; // 30s
 
-async function syncInstance(instanceId: string) {
-  const tasks = [
-    { key: `${instanceId}:prs`, fn: () => fetchPrs(instanceId) },
-    { key: `${instanceId}:recent-prs`, fn: () => fetchRecentPrs(instanceId) },
-    { key: `${instanceId}:reviews`, fn: () => fetchReviews(instanceId) },
-    {
-      key: `${instanceId}:notifications`,
-      fn: () => fetchNotifications(instanceId),
-    },
-  ];
+export type ResyncKey = "prs" | "recent-prs" | "reviews" | "notifications";
 
-  for (const task of tasks) {
-    try {
-      const data = await task.fn();
-      setCached(task.key, data);
-    } catch (err) {
-      console.error(
-        `Sync failed for ${task.key}:`,
-        err instanceof Error ? err.message : err,
-      );
-    }
+const RESYNC_FETCHERS: Record<
+  ResyncKey,
+  (instanceId: string) => Promise<unknown>
+> = {
+  prs: fetchPrs,
+  "recent-prs": fetchRecentPrs,
+  reviews: fetchReviews,
+  notifications: fetchNotifications,
+};
+
+const ALL_KEYS: ResyncKey[] = ["prs", "recent-prs", "reviews", "notifications"];
+
+const pending = new Set<Promise<unknown>>();
+
+export async function resyncInstance(
+  instanceId: string,
+  keys: ResyncKey[] = ALL_KEYS,
+): Promise<void> {
+  await Promise.all(
+    keys.map(async (key) => {
+      try {
+        const data = await RESYNC_FETCHERS[key](instanceId);
+        setCached(`${instanceId}:${key}`, data);
+      } catch (err) {
+        console.error(
+          `Sync failed for ${instanceId}:${key}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }),
+  );
+}
+
+/**
+ * Fire-and-forget resync after a mutation. Lets the route respond fast while
+ * the cache is refreshed in the background, so the next client poll sees the
+ * new state without waiting for the 30s sync cycle.
+ */
+export function scheduleResync(instanceId: string, keys: ResyncKey[]): void {
+  const p = resyncInstance(instanceId, keys).finally(() => {
+    pending.delete(p);
+  });
+  pending.add(p);
+}
+
+/** Test seam: await all in-flight resyncs. */
+export async function waitForPendingResyncs(): Promise<void> {
+  while (pending.size > 0) {
+    await Promise.allSettled(pending);
   }
 }
 
@@ -40,7 +70,7 @@ async function syncAll() {
     return;
   }
   console.log(`Syncing ${instances.length} instance(s)...`);
-  await Promise.all(instances.map((inst) => syncInstance(inst.id)));
+  await Promise.all(instances.map((inst) => resyncInstance(inst.id)));
   console.log("Sync complete");
 }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -50,6 +50,7 @@ import type {
   ReviewRequest,
 } from "./types";
 import { applyTheme, themeAtom } from "./theme";
+import * as mutations from "./mutations";
 
 type Tab = "all" | string;
 
@@ -284,6 +285,7 @@ interface FocusedItem {
   reviews?: { approved: string[]; changesRequested: string[] };
   reviewDecision?: string | null;
   autoMerge?: boolean;
+  draft?: boolean;
   notificationId?: string;
   author?: string;
   headBranch?: string;
@@ -301,7 +303,6 @@ interface CommentingPr {
 function getActionsForItem(
   item: FocusedItem,
   queryClient: ReturnType<typeof useQueryClient>,
-  onDone: () => void,
   setEditingPrNumber?: (prNumber: number) => void,
   setCommentingPr?: (pr: CommentingPr) => void,
 ): Action[] {
@@ -347,24 +348,26 @@ function getActionsForItem(
     item.instanceId &&
     !item.readOnly
   ) {
-    actions.push({
-      label: item.autoMerge ? "Disable auto-merge" : "Enable auto-merge",
-      key: "m",
-      onSelect: async () => {
-        queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-          old?.map((pr) =>
-            pr.number === item.number && pr.repo === item.repo
-              ? { ...pr, autoMerge: !item.autoMerge }
-              : pr,
-          ),
-        );
-        try {
-          await api.toggleAutoMerge(item.instanceId!, item.repo!, item.number!);
-        } catch {
-          onDone();
-        }
-      },
-    });
+    // GitHub rejects enablePullRequestAutoMerge on draft PRs.
+    if (item.autoMerge || !item.draft) {
+      actions.push({
+        label: item.autoMerge ? "Disable auto-merge" : "Enable auto-merge",
+        key: "m",
+        onSelect: () => {
+          mutations
+            .toggleAutoMerge(
+              queryClient,
+              {
+                instanceId: item.instanceId!,
+                repo: item.repo!,
+                number: item.number!,
+              },
+              !!item.autoMerge,
+            )
+            .catch(() => {});
+        },
+      });
+    }
 
     if (setEditingPrNumber) {
       actions.push({
@@ -393,12 +396,14 @@ function getActionsForItem(
     actions.push({
       label: "Rerun CI",
       key: "i",
-      onSelect: async () => {
-        try {
-          await api.rerunCi(item.instanceId!, item.repo!, item.number!);
-        } catch (err) {
-          console.error("Failed to rerun CI:", err);
-        }
+      onSelect: () => {
+        mutations
+          .rerunCi(queryClient, {
+            instanceId: item.instanceId!,
+            repo: item.repo!,
+            number: item.number!,
+          })
+          .catch(() => {});
       },
     });
   }
@@ -414,42 +419,30 @@ function getActionsForItem(
       label: "Approve",
       key: "a",
       confirm: "Are you sure you want to approve this PR?",
-      onSelect: async () => {
-        await api.approvePr(item.instanceId!, item.repo!, item.number!);
-        onDone();
+      onSelect: () => {
+        mutations
+          .approvePr(queryClient, {
+            instanceId: item.instanceId!,
+            repo: item.repo!,
+            number: item.number!,
+          })
+          .catch(() => {});
       },
     });
     actions.push({
       label: "Close",
       key: "x",
       confirm: "Are you sure you want to close this PR?",
-      onSelect: async () => {
-        // Optimistic: remove from open PRs, add to recent
-        queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-          old?.filter(
-            (pr) => !(pr.number === item.number && pr.repo === item.repo),
-          ),
-        );
-        queryClient.setQueriesData<RecentPR[]>(
-          { queryKey: ["recent-prs"] },
-          (old) => [
-            {
-              id: Date.now(),
-              number: item.number!,
-              title: item.title,
-              url: item.url,
-              repo: item.repo!,
-              updatedAt: new Date().toISOString(),
-              merged: false,
-            },
-            ...(old ?? []),
-          ],
-        );
-        try {
-          await api.closePr(item.instanceId!, item.repo!, item.number!);
-        } catch {
-          onDone(); // revert on failure
-        }
+      onSelect: () => {
+        mutations
+          .closePr(queryClient, {
+            instanceId: item.instanceId!,
+            repo: item.repo!,
+            number: item.number!,
+            title: item.title,
+            url: item.url,
+          })
+          .catch(() => {});
       },
     });
   }
@@ -764,19 +757,21 @@ function Dashboard({ source }: { source: DashboardSource }) {
       } else if (e.key === "m" && activeSection === "prs") {
         if (item?.repo && item.number && item.instanceId && !item.readOnly) {
           e.preventDefault();
-          queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-            old?.map((pr) =>
-              pr.number === item.number && pr.repo === item.repo
-                ? { ...pr, autoMerge: !item.autoMerge }
-                : pr,
-            ),
-          );
-          api
-            .toggleAutoMerge(item.instanceId, item.repo, item.number)
-            .catch(() => {
-              queryClient.invalidateQueries({ queryKey: ["prs"] });
-              toast.error("Failed to toggle auto-merge");
-            });
+          if (!item.autoMerge && item.draft) {
+            toast.error("Mark the PR as ready before enabling auto-merge");
+            return;
+          }
+          mutations
+            .toggleAutoMerge(
+              queryClient,
+              {
+                instanceId: item.instanceId,
+                repo: item.repo,
+                number: item.number,
+              },
+              !!item.autoMerge,
+            )
+            .catch(() => {});
         }
       } else if (
         e.key === "a" &&
@@ -790,11 +785,13 @@ function Dashboard({ source }: { source: DashboardSource }) {
           confirm("Approve this PR?")
         ) {
           e.preventDefault();
-          api.approvePr(item.instanceId, item.repo, item.number).then(() => {
-            queryClient.invalidateQueries({ queryKey: ["prs"] });
-            queryClient.invalidateQueries({ queryKey: ["reviews"] });
-            toast("PR approved");
-          });
+          mutations
+            .approvePr(queryClient, {
+              instanceId: item.instanceId,
+              repo: item.repo,
+              number: item.number,
+            })
+            .catch(() => {});
         }
       } else if (
         e.key === "c" &&
@@ -808,30 +805,15 @@ function Dashboard({ source }: { source: DashboardSource }) {
           confirm("Close this PR?")
         ) {
           e.preventDefault();
-          queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-            old?.filter(
-              (pr) => !(pr.number === item.number && pr.repo === item.repo),
-            ),
-          );
-          queryClient.setQueriesData<RecentPR[]>(
-            { queryKey: ["recent-prs"] },
-            (old) => [
-              {
-                id: Date.now(),
-                number: item.number!,
-                title: item.title,
-                url: item.url,
-                repo: item.repo!,
-                updatedAt: new Date().toISOString(),
-                merged: false,
-              },
-              ...(old ?? []),
-            ],
-          );
-          api.closePr(item.instanceId, item.repo, item.number).catch(() => {
-            queryClient.invalidateQueries({ queryKey: ["prs"] });
-            toast.error("Failed to close PR");
-          });
+          mutations
+            .closePr(queryClient, {
+              instanceId: item.instanceId,
+              repo: item.repo,
+              number: item.number,
+              title: item.title,
+              url: item.url,
+            })
+            .catch(() => {});
         }
       } else if (e.key === "d" && activeSection === "prs") {
         const pr = prsRef.current[focusIndex];
@@ -843,22 +825,18 @@ function Dashboard({ source }: { source: DashboardSource }) {
           !item.readOnly
         ) {
           e.preventDefault();
-          const newDraft = !pr.draft;
           setTogglingDraftId(pr.id);
-          queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-            old?.map((p) => (p.id === pr.id ? { ...p, draft: newDraft } : p)),
-          );
-          toast(newDraft ? "Marked as draft" : "Marked as ready for review");
-          api
-            .toggleDraft(item.instanceId, item.repo, item.number)
-            .catch(() => {
-              queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-                old?.map((p) =>
-                  p.id === pr.id ? { ...p, draft: !newDraft } : p,
-                ),
-              );
-              toast.error("Failed to toggle draft");
-            })
+          mutations
+            .toggleDraft(
+              queryClient,
+              {
+                instanceId: item.instanceId,
+                repo: item.repo,
+                number: item.number,
+              },
+              pr.draft,
+            )
+            .catch(() => {})
             .finally(() => setTogglingDraftId(null));
         }
       } else if (e.key === "e" && activeSection === "reviews") {
@@ -877,17 +855,12 @@ function Dashboard({ source }: { source: DashboardSource }) {
       } else if (e.key === "e" && activeSection === "notifications") {
         if (item?.notificationId && item.instanceId) {
           e.preventDefault();
-          queryClient.setQueriesData<Notification[]>(
-            { queryKey: ["notifications"] },
-            (old) => old?.filter((n) => n.id !== item.notificationId),
-          );
-          toast("Notification marked as done");
-          api
-            .dismissNotification(item.instanceId, item.notificationId)
-            .catch(() => {
-              queryClient.invalidateQueries({ queryKey: ["notifications"] });
-              toast.error("Failed to dismiss notification");
-            });
+          mutations
+            .dismissNotification(queryClient, {
+              instanceId: item.instanceId,
+              notificationId: item.notificationId,
+            })
+            .catch(() => {});
         }
       }
     };
@@ -926,18 +899,13 @@ function Dashboard({ source }: { source: DashboardSource }) {
               if (!pr) return;
               const instanceId = pr.instanceId ?? instances[0]?.id;
               if (!instanceId) return;
-              queryClient.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
-                old?.map((p) =>
-                  p.number === prNumber && p.repo === pr.repo
-                    ? { ...p, title }
-                    : p,
-                ),
-              );
-              try {
-                await api.updatePrTitle(instanceId, pr.repo, prNumber, title);
-              } catch {
-                queryClient.invalidateQueries({ queryKey: ["prs"] });
-              }
+              await mutations
+                .updatePrTitle(
+                  queryClient,
+                  { instanceId, repo: pr.repo, number: prNumber },
+                  title,
+                )
+                .catch(() => {});
               setEditingPrNumber(null);
             }}
           />
@@ -997,10 +965,6 @@ function Dashboard({ source }: { source: DashboardSource }) {
           actions={getActionsForItem(
             actionMenu,
             queryClient,
-            () => {
-              queryClient.invalidateQueries({ queryKey: ["prs"] });
-              queryClient.invalidateQueries({ queryKey: ["reviews"] });
-            },
             (num) => {
               setEditingPrNumber(num);
               if (panelItem) closePanel();
@@ -1107,6 +1071,7 @@ function getFocusedItem(
       reviews: p.reviews,
       reviewDecision: p.reviewDecision,
       autoMerge: p.autoMerge,
+      draft: p.draft,
       author: p.author,
       headBranch: p.headBranch,
       baseBranch: p.baseBranch,
@@ -1147,6 +1112,7 @@ function getFocusedItem(
       deletions: r.deletions,
       reviews: r.reviews,
       reviewDecision: r.reviewDecision,
+      draft: r.draft,
       author: r.author,
       headBranch: r.headBranch,
       baseBranch: r.baseBranch,

--- a/packages/web/src/components/PrCard.tsx
+++ b/packages/web/src/components/PrCard.tsx
@@ -134,17 +134,17 @@ export function PrCard({
       <div className="absolute bottom-2 right-2 flex flex-col items-end gap-0.5">
         {createdAt && (
           <span className="flex items-center gap-1">
-            <Text size="small" variant="tertiary">
+            <Text size="small" variant="tertiary" className="text-[10px]">
               opened
             </Text>
-            <TimeAgo date={createdAt} />
+            <TimeAgo date={createdAt} className="text-[10px]" />
           </span>
         )}
         <span className="flex items-center gap-1">
-          <Text size="small" variant="tertiary">
-            pushed
+          <Text size="small" variant="tertiary" className="text-[10px]">
+            updated
           </Text>
-          <TimeAgo date={updatedAt} />
+          <TimeAgo date={updatedAt} className="text-[10px]" />
         </span>
       </div>
       <div className="flex">

--- a/packages/web/src/components/TimeAgo.tsx
+++ b/packages/web/src/components/TimeAgo.tsx
@@ -11,9 +11,15 @@ function timeAgo(date: string): string {
   return `${days}d ago`;
 }
 
-export function TimeAgo({ date }: { date: string }) {
+export function TimeAgo({
+  date,
+  className,
+}: {
+  date: string;
+  className?: string;
+}) {
   return (
-    <Text size="small" variant="secondary" title={date}>
+    <Text size="small" variant="secondary" title={date} className={className}>
       {timeAgo(date)}
     </Text>
   );

--- a/packages/web/src/mutations.ts
+++ b/packages/web/src/mutations.ts
@@ -1,0 +1,181 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "./api";
+import type { Notification, PR, RecentPR, ReviewRequest } from "./types";
+
+interface Target {
+  instanceId: string;
+  repo: string;
+  number: number;
+}
+
+type Snapshot<T> = [readonly unknown[], T | undefined][];
+
+function snapshot<T>(qc: QueryClient, key: string): Snapshot<T> {
+  return qc.getQueriesData<T>({ queryKey: [key] });
+}
+
+function restore<T>(qc: QueryClient, snap: Snapshot<T>) {
+  for (const [key, data] of snap) {
+    qc.setQueryData(key, data);
+  }
+}
+
+const matches =
+  (target: Target) =>
+  (item: { repo: string; number: number }): boolean =>
+    item.number === target.number && item.repo === target.repo;
+
+export async function approvePr(
+  qc: QueryClient,
+  target: Target,
+): Promise<void> {
+  // Approve removes the PR from MY review-requests list (no longer awaiting me).
+  const snap = snapshot<ReviewRequest[]>(qc, "reviews");
+  qc.setQueriesData<ReviewRequest[]>({ queryKey: ["reviews"] }, (old) =>
+    old?.filter((r) => !matches(target)(r)),
+  );
+  try {
+    await api.approvePr(target.instanceId, target.repo, target.number);
+    toast.success("PR approved");
+  } catch (err) {
+    restore(qc, snap);
+    toast.error("Failed to approve PR");
+    throw err;
+  }
+}
+
+export async function toggleAutoMerge(
+  qc: QueryClient,
+  target: Target,
+  current: boolean,
+): Promise<void> {
+  const snap = snapshot<PR[]>(qc, "prs");
+  qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
+    old?.map((pr) =>
+      matches(target)(pr) ? { ...pr, autoMerge: !current } : pr,
+    ),
+  );
+  try {
+    await api.toggleAutoMerge(target.instanceId, target.repo, target.number);
+  } catch (err) {
+    restore(qc, snap);
+    toast.error("Failed to toggle auto-merge");
+    throw err;
+  }
+}
+
+export async function closePr(
+  qc: QueryClient,
+  target: Target & { title: string; url: string },
+): Promise<void> {
+  const prsSnap = snapshot<PR[]>(qc, "prs");
+  const reviewsSnap = snapshot<ReviewRequest[]>(qc, "reviews");
+  const recentSnap = snapshot<RecentPR[]>(qc, "recent-prs");
+
+  qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
+    old?.filter((pr) => !matches(target)(pr)),
+  );
+  qc.setQueriesData<ReviewRequest[]>({ queryKey: ["reviews"] }, (old) =>
+    old?.filter((r) => !matches(target)(r)),
+  );
+  qc.setQueriesData<RecentPR[]>({ queryKey: ["recent-prs"] }, (old) => [
+    {
+      id: Date.now(),
+      number: target.number,
+      title: target.title,
+      url: target.url,
+      repo: target.repo,
+      updatedAt: new Date().toISOString(),
+      merged: false,
+    },
+    ...(old ?? []),
+  ]);
+
+  try {
+    await api.closePr(target.instanceId, target.repo, target.number);
+    toast.success("PR closed");
+  } catch (err) {
+    restore(qc, prsSnap);
+    restore(qc, reviewsSnap);
+    restore(qc, recentSnap);
+    toast.error("Failed to close PR");
+    throw err;
+  }
+}
+
+export async function toggleDraft(
+  qc: QueryClient,
+  target: Target,
+  current: boolean,
+): Promise<void> {
+  const snap = snapshot<PR[]>(qc, "prs");
+  qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
+    old?.map((pr) => (matches(target)(pr) ? { ...pr, draft: !current } : pr)),
+  );
+  toast(current ? "Marked as ready for review" : "Marked as draft");
+  try {
+    await api.toggleDraft(target.instanceId, target.repo, target.number);
+  } catch (err) {
+    restore(qc, snap);
+    toast.error("Failed to toggle draft");
+    throw err;
+  }
+}
+
+export async function dismissNotification(
+  qc: QueryClient,
+  target: { instanceId: string; notificationId: string },
+): Promise<void> {
+  const snap = snapshot<Notification[]>(qc, "notifications");
+  qc.setQueriesData<Notification[]>({ queryKey: ["notifications"] }, (old) =>
+    old?.filter((n) => n.id !== target.notificationId),
+  );
+  try {
+    await api.dismissNotification(target.instanceId, target.notificationId);
+  } catch (err) {
+    restore(qc, snap);
+    toast.error("Failed to dismiss notification");
+    throw err;
+  }
+}
+
+export async function updatePrTitle(
+  qc: QueryClient,
+  target: Target,
+  title: string,
+): Promise<void> {
+  const snap = snapshot<PR[]>(qc, "prs");
+  qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
+    old?.map((pr) => (matches(target)(pr) ? { ...pr, title } : pr)),
+  );
+  try {
+    await api.updatePrTitle(
+      target.instanceId,
+      target.repo,
+      target.number,
+      title,
+    );
+  } catch (err) {
+    restore(qc, snap);
+    toast.error("Failed to update title");
+    throw err;
+  }
+}
+
+export async function rerunCi(qc: QueryClient, target: Target): Promise<void> {
+  const snap = snapshot<PR[]>(qc, "prs");
+  qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
+    old?.map((pr) =>
+      matches(target)(pr) ? { ...pr, ciStatus: "pending" } : pr,
+    ),
+  );
+  try {
+    await api.rerunCi(target.instanceId, target.repo, target.number);
+    toast.success("CI rerun started");
+  } catch (err) {
+    restore(qc, snap);
+    toast.error("Failed to rerun CI");
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

- Server: mutation endpoints now `scheduleResync(instanceId, keys)` instead of nulling caches. Targeted background refetch repopulates the cache so the next 10s client poll sees fresh state without waiting for the 30s sync cycle.
- Web: optimistic update + rollback logic moved out of `App.tsx` into a shared `mutations.ts` module (approve / close / toggleAutoMerge / toggleDraft / dismissNotification / updatePrTitle / rerunCi). Hides "Enable auto-merge" on draft PRs since GitHub rejects the mutation.
- Drive-by: PR card timestamps relabel "pushed" → "updated" and shrink to 10px.

Closes #9

## Test plan

- [x] `pnpm -r test` (74 server + 4 web)
- [x] `pnpm -w typecheck`, `pnpm -w lint`, `pnpm -w fmt:check`
- [ ] Smoke: approve / close / toggle auto-merge / toggle draft / dismiss notification / rename title / rerun CI — UI updates immediately and reconciles with server within ~10s
- [ ] Verify "Enable auto-merge" hidden on draft PRs; pressing `m` on a draft shows toast instead of failing