### PR TITLE
fix rerun CI to handle multi-workflow PRs

### DIFF
--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -39,6 +39,7 @@ const { cacheStore, configStub, fetchersStub, mockOctokit, octokitHolder } =
         actions: {
           listWorkflowRunsForRepo: vi.fn(),
           reRunWorkflow: vi.fn(),
+          reRunWorkflowFailedJobs: vi.fn(),
         },
         search: { issuesAndPullRequests: vi.fn() },
         graphql: vi.fn(),
@@ -424,23 +425,124 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/rerun-ci", () => {
     const res = await call("/github/prs/o/r/5/rerun-ci", { method: "POST" });
     expect(res.status).toBe(404);
     expect(mockOctokit.actions.reRunWorkflow).not.toHaveBeenCalled();
+    expect(mockOctokit.actions.reRunWorkflowFailedJobs).not.toHaveBeenCalled();
   });
 
-  it("reruns the latest workflow run", async () => {
+  it("404s when no completed PR-triggered runs are found", async () => {
     mockOctokit.pulls.get.mockResolvedValue({
       data: { head: { sha: "abc" }, node_id: "PR_1" },
     });
     mockOctokit.actions.listWorkflowRunsForRepo.mockResolvedValue({
-      data: { workflow_runs: [{ id: 777 }] },
+      data: {
+        workflow_runs: [
+          // Wrong event
+          {
+            id: 1,
+            workflow_id: 10,
+            event: "push",
+            status: "completed",
+            conclusion: "success",
+          },
+          // Still running
+          {
+            id: 2,
+            workflow_id: 11,
+            event: "pull_request",
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+      },
+    });
+    const res = await call("/github/prs/o/r/5/rerun-ci", { method: "POST" });
+    expect(res.status).toBe(404);
+    expect(mockOctokit.actions.reRunWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("reruns failed jobs for failed runs and full workflow for passing runs", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { head: { sha: "abc" }, node_id: "PR_1" },
+    });
+    mockOctokit.actions.listWorkflowRunsForRepo.mockResolvedValue({
+      data: {
+        workflow_runs: [
+          // Newer attempt of workflow 20 — should win
+          {
+            id: 200,
+            workflow_id: 20,
+            event: "pull_request",
+            status: "completed",
+            conclusion: "failure",
+          },
+          // Older attempt of workflow 20 — should be ignored
+          {
+            id: 199,
+            workflow_id: 20,
+            event: "pull_request",
+            status: "completed",
+            conclusion: "success",
+          },
+          // Different workflow, success
+          {
+            id: 300,
+            workflow_id: 30,
+            event: "pull_request",
+            status: "completed",
+            conclusion: "success",
+          },
+          // Wrong event
+          {
+            id: 400,
+            workflow_id: 40,
+            event: "push",
+            status: "completed",
+            conclusion: "failure",
+          },
+        ],
+      },
     });
     mockOctokit.actions.reRunWorkflow.mockResolvedValue({});
+    mockOctokit.actions.reRunWorkflowFailedJobs.mockResolvedValue({});
     const res = await call("/github/prs/o/r/5/rerun-ci", { method: "POST" });
     expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, triggered: 2 });
+    expect(mockOctokit.actions.reRunWorkflowFailedJobs).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      run_id: 200,
+    });
     expect(mockOctokit.actions.reRunWorkflow).toHaveBeenCalledWith({
       owner: "o",
       repo: "r",
-      run_id: 777,
+      run_id: 300,
     });
+    expect(mockOctokit.actions.reRunWorkflow).not.toHaveBeenCalledWith(
+      expect.objectContaining({ run_id: 400 }),
+    );
+  });
+
+  it("502s when every rerun call fails", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { head: { sha: "abc" }, node_id: "PR_1" },
+    });
+    mockOctokit.actions.listWorkflowRunsForRepo.mockResolvedValue({
+      data: {
+        workflow_runs: [
+          {
+            id: 500,
+            workflow_id: 50,
+            event: "pull_request",
+            status: "completed",
+            conclusion: "failure",
+          },
+        ],
+      },
+    });
+    mockOctokit.actions.reRunWorkflowFailedJobs.mockRejectedValue(
+      new Error("boom"),
+    );
+    const res = await call("/github/prs/o/r/5/rerun-ci", { method: "POST" });
+    expect(res.status).toBe(502);
   });
 });
 

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -349,21 +349,62 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/rerun-ci", async (c) => {
       owner,
       repo,
       head_sha: pr.head.sha,
-      per_page: 1,
+      per_page: 100,
     })
     .catch(() => null);
 
-  const latestRun = runsRes?.data.workflow_runs[0];
-
-  if (!latestRun) {
-    return c.json({ error: "No workflow runs found" }, 404);
+  // Keep only the latest attempt per workflow_id, and only for PR-triggered events
+  const latestPerWorkflow = new Map<
+    number,
+    { id: number; status: string; conclusion: string | null }
+  >();
+  for (const run of runsRes?.data.workflow_runs ?? []) {
+    if (run.event !== "pull_request" && run.event !== "pull_request_target") {
+      continue;
+    }
+    const existing = latestPerWorkflow.get(run.workflow_id);
+    if (!existing) {
+      latestPerWorkflow.set(run.workflow_id, {
+        id: run.id,
+        status: run.status ?? "",
+        conclusion: run.conclusion,
+      });
+    }
   }
 
-  await client.actions.reRunWorkflow({ owner, repo, run_id: latestRun.id });
+  const candidates = [...latestPerWorkflow.values()].filter(
+    (r) => r.status === "completed",
+  );
+
+  if (candidates.length === 0) {
+    return c.json({ error: "No rerunnable workflow runs found" }, 404);
+  }
+
+  const results = await Promise.allSettled(
+    candidates.map((run) => {
+      const failed =
+        run.conclusion === "failure" ||
+        run.conclusion === "timed_out" ||
+        run.conclusion === "cancelled";
+      return failed
+        ? client.actions.reRunWorkflowFailedJobs({
+            owner,
+            repo,
+            run_id: run.id,
+          })
+        : client.actions.reRunWorkflow({ owner, repo, run_id: run.id });
+    }),
+  );
+
+  const triggered = results.filter((r) => r.status === "fulfilled").length;
+
+  if (triggered === 0) {
+    return c.json({ error: "Failed to rerun any workflow" }, 502);
+  }
 
   scheduleResync(instanceId, ["prs"]);
 
-  return c.json({ ok: true });
+  return c.json({ ok: true, triggered });
 });
 
 // Post a comment on a PR

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -292,6 +292,7 @@ interface FocusedItem {
   baseBranch?: string;
   commentCount?: number;
   readOnly?: boolean;
+  ciStatus?: string;
 }
 
 interface CommentingPr {
@@ -393,19 +394,21 @@ function getActionsForItem(
       });
     }
 
-    actions.push({
-      label: "Rerun CI",
-      key: "i",
-      onSelect: () => {
-        mutations
-          .rerunCi(queryClient, {
-            instanceId: item.instanceId!,
-            repo: item.repo!,
-            number: item.number!,
-          })
-          .catch(() => {});
-      },
-    });
+    if (item.ciStatus === "failure") {
+      actions.push({
+        label: "Rerun failed jobs",
+        key: "i",
+        onSelect: () => {
+          mutations
+            .rerunCi(queryClient, {
+              instanceId: item.instanceId!,
+              repo: item.repo!,
+              number: item.number!,
+            })
+            .catch(() => {});
+        },
+      });
+    }
   }
 
   if (
@@ -1076,6 +1079,7 @@ function getFocusedItem(
       headBranch: p.headBranch,
       baseBranch: p.baseBranch,
       commentCount: p.commentCount,
+      ciStatus: p.ciStatus,
     };
   }
   if (section === "prs" && recentPrs[idx - prs.length]) {

--- a/packages/web/src/mutations.ts
+++ b/packages/web/src/mutations.ts
@@ -172,10 +172,10 @@ export async function rerunCi(qc: QueryClient, target: Target): Promise<void> {
   );
   try {
     await api.rerunCi(target.instanceId, target.repo, target.number);
-    toast.success("CI rerun started");
+    toast.success("Rerunning failed jobs");
   } catch (err) {
     restore(qc, snap);
-    toast.error("Failed to rerun CI");
+    toast.error("Failed to rerun jobs");
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- The Rerun CI action picked only the most recent workflow run for the PR head SHA (`per_page: 1`). On repos with multiple workflows or unrelated events on the same SHA (push/deploy), it would either pick the wrong run or one that was already passing — the API call succeeded but nothing useful was triggered, so the optimistic update flipped CI to pending and then reverted with no actual rerun.
- Fetch up to 100 runs, keep the latest attempt per `workflow_id` filtered to `pull_request` / `pull_request_target` events, and rerun every completed one. Failed / timed-out / cancelled runs use `reRunWorkflowFailedJobs`; passing runs use `reRunWorkflow`.
- Returns 502 if every rerun call fails so the toast no longer lies. Response body now includes `triggered` (count of successful rerun calls).

> Stacked on `an/resync-after-mutations`.

## Test plan
- [x] Server tests pass (76 tests)
- [ ] Manually rerun CI on a PR with multiple workflows
- [ ] Manually rerun CI on a PR where one workflow failed and another passed