### PR TITLE
dedupe check runs by name when computing CI status

### DIFF
--- a/packages/server/src/fetchers.test.ts
+++ b/packages/server/src/fetchers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { getCiStatus, summarizeReviews } from "./fetchers.js";
+import {
+  getCiStatus,
+  latestCheckRunsByName,
+  summarizeReviews,
+} from "./fetchers.js";
 
 describe("summarizeReviews", () => {
   it("returns empty arrays when no reviews", () => {
@@ -52,7 +56,12 @@ describe("summarizeReviews", () => {
 
 function mockClient(overrides: {
   statuses?: { state: string }[];
-  checks?: { status: string; conclusion: string | null }[];
+  checks?: {
+    name?: string;
+    status: string;
+    conclusion: string | null;
+    completed_at?: string | null;
+  }[];
   statusesError?: boolean;
   checksError?: boolean;
 }) {
@@ -85,8 +94,8 @@ describe("getCiStatus", () => {
     const result = await getCiStatus(
       mockClient({
         checks: [
-          { status: "in_progress", conclusion: null },
-          { status: "completed", conclusion: "success" },
+          { name: "lint", status: "in_progress", conclusion: null },
+          { name: "test", status: "completed", conclusion: "success" },
         ],
       }),
       "o",
@@ -94,6 +103,62 @@ describe("getCiStatus", () => {
       "ref",
     );
     expect(result).toBe("pending");
+  });
+
+  it("ignores stale check attempts when a newer one passed (rerun)", async () => {
+    const result = await getCiStatus(
+      mockClient({
+        checks: [
+          {
+            name: "Validate Title",
+            status: "completed",
+            conclusion: "failure",
+            completed_at: "2026-04-28T10:00:00Z",
+          },
+          {
+            name: "Validate Title",
+            status: "completed",
+            conclusion: "success",
+            completed_at: "2026-04-28T11:00:00Z",
+          },
+          {
+            name: "Tests",
+            status: "completed",
+            conclusion: "success",
+            completed_at: "2026-04-28T11:00:00Z",
+          },
+        ],
+      }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("success");
+  });
+
+  it("uses the latest attempt regardless of API ordering", async () => {
+    const result = await getCiStatus(
+      mockClient({
+        checks: [
+          {
+            name: "Build",
+            status: "completed",
+            conclusion: "success",
+            completed_at: "2026-04-28T10:00:00Z",
+          },
+          {
+            name: "Build",
+            status: "completed",
+            conclusion: "failure",
+            completed_at: "2026-04-28T11:00:00Z",
+          },
+        ],
+      }),
+      "o",
+      "r",
+      "ref",
+    );
+    expect(result).toBe("failure");
   });
 
   it("returns 'failure' on failed legacy status", async () => {
@@ -150,5 +215,52 @@ describe("getCiStatus", () => {
       "ref",
     );
     expect(result).toBe("unknown");
+  });
+});
+
+describe("latestCheckRunsByName", () => {
+  it("keeps the most recent attempt per name by completed_at", () => {
+    const result = latestCheckRunsByName([
+      {
+        name: "a",
+        status: "completed",
+        conclusion: "failure",
+        completed_at: "2026-04-28T10:00:00Z",
+      },
+      {
+        name: "a",
+        status: "completed",
+        conclusion: "success",
+        completed_at: "2026-04-28T11:00:00Z",
+      },
+      {
+        name: "b",
+        status: "completed",
+        conclusion: "success",
+        completed_at: "2026-04-28T09:00:00Z",
+      },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.name === "a")?.conclusion).toBe("success");
+    expect(result.find((r) => r.name === "b")?.conclusion).toBe("success");
+  });
+
+  it("falls back to started_at when completed_at is missing", () => {
+    const result = latestCheckRunsByName([
+      {
+        name: "a",
+        status: "in_progress",
+        conclusion: null,
+        started_at: "2026-04-28T11:00:00Z",
+      },
+      {
+        name: "a",
+        status: "completed",
+        conclusion: "failure",
+        completed_at: "2026-04-28T10:00:00Z",
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("in_progress");
   });
 });

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -49,6 +49,32 @@ export async function fetchMergeQueueStatus(
   return result;
 }
 
+type CheckRun = {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+};
+
+// listForRef can return multiple attempts of the same named check (e.g. after
+// a rerun). Keep only the most recent attempt per name so a stale failure
+// doesn't outvote a later success.
+export function latestCheckRunsByName<T extends CheckRun>(runs: T[]): T[] {
+  const latest = new Map<string, T>();
+  const ts = (r: T) => {
+    const t = r.completed_at ?? r.started_at;
+    return t ? new Date(t).getTime() : 0;
+  };
+  for (const r of runs) {
+    const existing = latest.get(r.name);
+    if (!existing || ts(r) >= ts(existing)) {
+      latest.set(r.name, r);
+    }
+  }
+  return [...latest.values()];
+}
+
 export async function getCiStatus(
   client: Octokit,
   owner: string,
@@ -65,7 +91,7 @@ export async function getCiStatus(
   ]);
 
   const statuses = statusRes?.data.statuses ?? [];
-  const checkRuns = checksRes?.data.check_runs ?? [];
+  const checkRuns = latestCheckRunsByName(checksRes?.data.check_runs ?? []);
 
   // No CI configured at all
   if (statuses.length === 0 && checkRuns.length === 0) return "unknown";

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -16,6 +16,11 @@ const { cacheStore, configStub, fetchersStub, mockOctokit, octokitHolder } =
         fetchRecentPrs: vi.fn(),
         fetchReviews: vi.fn(),
         fetchNotifications: vi.fn(),
+        latestCheckRunsByName: <T extends { name: string }>(runs: T[]): T[] => {
+          const m = new Map<string, T>();
+          for (const r of runs) m.set(r.name, r);
+          return [...m.values()];
+        },
       },
       mockOctokit: {
         users: { getAuthenticated: vi.fn() },

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -14,6 +14,7 @@ import {
   fetchPrs,
   fetchRecentPrs,
   fetchReviews,
+  latestCheckRunsByName,
 } from "./fetchers.js";
 import { clearClients, getClient, getInstance } from "./github-client.js";
 
@@ -410,7 +411,7 @@ api.get("/:instanceId/prs/:owner/:repo/:prNumber/meta", async (c) => {
     });
   }
 
-  for (const cr of checksRes?.data.check_runs ?? []) {
+  for (const cr of latestCheckRunsByName(checksRes?.data.check_runs ?? [])) {
     checksByName.set(cr.name, {
       name: cr.name,
       status: cr.status,


### PR DESCRIPTION
## Summary
- `client.checks.listForRef` returns every attempt of a named check across check_suites, not just the latest. A stale failed attempt could outvote a later success on the same name (e.g. a check that was rerun and passed). The dashboard then showed `failing` while GitHub's UI showed all green.
- Pick the most recent attempt per name (by `completed_at`, falling back to `started_at`) before evaluating pending/failure in `getCiStatus`.
- Apply the same dedupe in the `/meta` endpoint so the side panel matches.

Real example that triggered this: `Validate Title` returned both a `failure` and a `success` check-run on the same SHA — only the latest is shown in the GitHub UI but both came back from the API.

## Test plan
- [x] `latestCheckRunsByName` unit tests (latest by completed_at, fallback to started_at)
- [x] `getCiStatus` returns `success` when a stale failure is followed by a later success
- [x] Existing 78 server tests pass
- [ ] Manually verify the affected PR card now reads green