### PR TITLE
unify M as 'merge this PR' with confirmation

### DIFF
--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -121,7 +121,7 @@ describe("fetchPrs", () => {
     expect(prs.map((p) => p.author)).toEqual(["alice"]);
   });
 
-  it("populates mergeQueue + autoMerge + reviewDecision from GraphQL", async () => {
+  it("populates mergeQueue + autoMerge + reviewDecision + threads from GraphQL", async () => {
     mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
       data: { items: [prSearchItem()] },
     });
@@ -131,6 +131,14 @@ describe("fetchPrs", () => {
         mergeQueueEntry: { id: "MQ_1" },
         autoMergeRequest: { enabledAt: "x" },
         reviewDecision: "APPROVED",
+        mergeStateStatus: "BLOCKED",
+        reviewThreads: {
+          nodes: [
+            { isResolved: false },
+            { isResolved: false },
+            { isResolved: true },
+          ],
+        },
       },
     });
     const prs = await fetchPrs("github");
@@ -138,6 +146,8 @@ describe("fetchPrs", () => {
       inMergeQueue: true,
       autoMerge: true,
       reviewDecision: "APPROVED",
+      mergeStateStatus: "BLOCKED",
+      unresolvedThreadCount: 2,
     });
   });
 
@@ -151,6 +161,8 @@ describe("fetchPrs", () => {
       inMergeQueue: false,
       autoMerge: false,
       reviewDecision: null,
+      mergeStateStatus: null,
+      unresolvedThreadCount: 0,
     });
   });
 

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockOctokit } = vi.hoisted(() => ({
+const { mockOctokit, cacheStore } = vi.hoisted(() => ({
   mockOctokit: {
     search: { issuesAndPullRequests: vi.fn() },
     pulls: { get: vi.fn(), listReviews: vi.fn() },
     checks: { listForRef: vi.fn() },
-    repos: { getCombinedStatusForRef: vi.fn() },
+    repos: { getCombinedStatusForRef: vi.fn(), get: vi.fn() },
     activity: { listNotificationsForAuthenticatedUser: vi.fn() },
     graphql: vi.fn(),
   },
+  cacheStore: new Map<string, unknown>(),
 }));
 
 vi.mock("./github-client.js", () => ({
@@ -22,14 +23,25 @@ vi.mock("./github-client.js", () => ({
   }),
 }));
 
+vi.mock("./cache.js", () => ({
+  getCached: (key: string) => cacheStore.get(key) ?? null,
+  setCached: (key: string, data: unknown) => {
+    cacheStore.set(key, data);
+  },
+}));
+
 const { fetchPrs, fetchNotifications, fetchRecentPrs } = await import(
   "./fetchers.js"
 );
 
 beforeEach(() => {
   vi.clearAllMocks();
+  cacheStore.clear();
   // Safe defaults
   mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] });
+  mockOctokit.repos.get.mockResolvedValue({
+    data: { allow_auto_merge: false },
+  });
   mockOctokit.pulls.get.mockResolvedValue({
     data: {
       body: "",
@@ -149,6 +161,33 @@ describe("fetchPrs", () => {
     const prs = await fetchPrs("github");
     expect(prs).toEqual([]);
     expect(mockOctokit.graphql).not.toHaveBeenCalled();
+  });
+
+  it("attaches autoMergeAllowed from repo settings and caches per repo", async () => {
+    mockOctokit.repos.get.mockResolvedValue({
+      data: { allow_auto_merge: true },
+    });
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          prSearchItem(),
+          prSearchItem({ id: 2, node_id: "PR_2", number: 6 }),
+        ],
+      },
+    });
+    const prs = await fetchPrs("github");
+    expect(prs.map((p) => p.autoMergeAllowed)).toEqual([true, true]);
+    // Both PRs share the same repo — settings call should hit cache after the first.
+    expect(mockOctokit.repos.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults autoMergeAllowed to false when repos.get fails", async () => {
+    mockOctokit.repos.get.mockRejectedValue(new Error("403"));
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [prSearchItem()] },
+    });
+    const prs = await fetchPrs("github");
+    expect(prs[0].autoMergeAllowed).toBe(false);
   });
 });
 

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -43,6 +43,7 @@ interface MergeQueueInfo {
   inMergeQueue: boolean;
   autoMerge: boolean;
   reviewDecision: string | null;
+  mergeStateStatus: string | null;
 }
 
 export async function fetchMergeQueueStatus(
@@ -54,7 +55,7 @@ export async function fetchMergeQueueStatus(
 
   // Build a batched GraphQL query
   const aliases = items.map((item, i) => {
-    return `pr${i}: node(id: "${item.node_id}") { ... on PullRequest { id mergeQueueEntry { id } autoMergeRequest { enabledAt } reviewDecision } }`;
+    return `pr${i}: node(id: "${item.node_id}") { ... on PullRequest { id mergeQueueEntry { id } autoMergeRequest { enabledAt } reviewDecision mergeStateStatus } }`;
   });
 
   try {
@@ -66,6 +67,7 @@ export async function fetchMergeQueueStatus(
           mergeQueueEntry: { id: string } | null;
           autoMergeRequest: { enabledAt: string } | null;
           reviewDecision: string | null;
+          mergeStateStatus: string | null;
         } | null
       >
     >(`query { ${aliases.join("\n")} }`);
@@ -76,6 +78,7 @@ export async function fetchMergeQueueStatus(
         inMergeQueue: pr?.mergeQueueEntry != null,
         autoMerge: pr?.autoMergeRequest != null,
         reviewDecision: pr?.reviewDecision ?? null,
+        mergeStateStatus: pr?.mergeStateStatus ?? null,
       });
     }
   } catch {
@@ -226,6 +229,7 @@ export async function fetchPrs(instanceId: string) {
         baseBranch: prData?.base.ref ?? "main",
         reviews: summarizeReviews(reviews),
         reviewDecision: mqStatus?.reviewDecision ?? null,
+        mergeStateStatus: mqStatus?.mergeStateStatus ?? null,
         additions: prData?.additions ?? 0,
         deletions: prData?.deletions ?? 0,
         commits: prData?.commits ?? 0,
@@ -342,6 +346,7 @@ export async function fetchReviews(instanceId: string) {
         baseBranch: prData?.base.ref ?? "main",
         reviews: summarizeReviews(reviews),
         reviewDecision: mqStatus?.reviewDecision ?? null,
+        mergeStateStatus: mqStatus?.mergeStateStatus ?? null,
         additions: prData?.additions ?? 0,
         deletions: prData?.deletions ?? 0,
         commits: prData?.commits ?? 0,

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -44,6 +44,7 @@ interface MergeQueueInfo {
   autoMerge: boolean;
   reviewDecision: string | null;
   mergeStateStatus: string | null;
+  unresolvedThreadCount: number;
 }
 
 export async function fetchMergeQueueStatus(
@@ -55,7 +56,7 @@ export async function fetchMergeQueueStatus(
 
   // Build a batched GraphQL query
   const aliases = items.map((item, i) => {
-    return `pr${i}: node(id: "${item.node_id}") { ... on PullRequest { id mergeQueueEntry { id } autoMergeRequest { enabledAt } reviewDecision mergeStateStatus } }`;
+    return `pr${i}: node(id: "${item.node_id}") { ... on PullRequest { id mergeQueueEntry { id } autoMergeRequest { enabledAt } reviewDecision mergeStateStatus reviewThreads(first: 100) { nodes { isResolved } } } }`;
   });
 
   try {
@@ -68,17 +69,21 @@ export async function fetchMergeQueueStatus(
           autoMergeRequest: { enabledAt: string } | null;
           reviewDecision: string | null;
           mergeStateStatus: string | null;
+          reviewThreads: { nodes: { isResolved: boolean }[] } | null;
         } | null
       >
     >(`query { ${aliases.join("\n")} }`);
 
     for (let i = 0; i < items.length; i++) {
       const pr = response[`pr${i}`];
+      const threads = pr?.reviewThreads?.nodes ?? [];
+      const unresolvedThreadCount = threads.filter((t) => !t.isResolved).length;
       result.set(items[i].node_id, {
         inMergeQueue: pr?.mergeQueueEntry != null,
         autoMerge: pr?.autoMergeRequest != null,
         reviewDecision: pr?.reviewDecision ?? null,
         mergeStateStatus: pr?.mergeStateStatus ?? null,
+        unresolvedThreadCount,
       });
     }
   } catch {
@@ -230,6 +235,7 @@ export async function fetchPrs(instanceId: string) {
         reviews: summarizeReviews(reviews),
         reviewDecision: mqStatus?.reviewDecision ?? null,
         mergeStateStatus: mqStatus?.mergeStateStatus ?? null,
+        unresolvedThreadCount: mqStatus?.unresolvedThreadCount ?? 0,
         additions: prData?.additions ?? 0,
         deletions: prData?.deletions ?? 0,
         commits: prData?.commits ?? 0,
@@ -347,6 +353,7 @@ export async function fetchReviews(instanceId: string) {
         reviews: summarizeReviews(reviews),
         reviewDecision: mqStatus?.reviewDecision ?? null,
         mergeStateStatus: mqStatus?.mergeStateStatus ?? null,
+        unresolvedThreadCount: mqStatus?.unresolvedThreadCount ?? 0,
         additions: prData?.additions ?? 0,
         deletions: prData?.deletions ?? 0,
         commits: prData?.commits ?? 0,

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -1,5 +1,41 @@
 import type { Octokit } from "@octokit/rest";
+import { getCached, setCached } from "./cache.js";
 import { getClient, getInstance } from "./github-client.js";
+
+interface RepoSettings {
+  autoMergeAllowed: boolean;
+}
+
+const inFlightRepoSettings = new Map<string, Promise<RepoSettings>>();
+
+export async function getRepoSettings(
+  client: Octokit,
+  instanceId: string,
+  owner: string,
+  repo: string,
+): Promise<RepoSettings> {
+  const key = `${instanceId}:repo-settings:${owner}/${repo}`;
+  const cached = getCached<RepoSettings>(key);
+  if (cached) return cached;
+  const existing = inFlightRepoSettings.get(key);
+  if (existing) return existing;
+  const promise = (async () => {
+    try {
+      const { data } = await client.repos.get({ owner, repo });
+      const settings: RepoSettings = {
+        autoMergeAllowed: data.allow_auto_merge ?? false,
+      };
+      setCached(key, settings);
+      return settings;
+    } catch {
+      return { autoMergeAllowed: false };
+    } finally {
+      inFlightRepoSettings.delete(key);
+    }
+  })();
+  inFlightRepoSettings.set(key, promise);
+  return promise;
+}
 
 type Review = { state: string; user: { login: string } | null };
 
@@ -154,7 +190,7 @@ export async function fetchPrs(instanceId: string) {
       const [owner, repo] = item.repository_url.split("/").slice(-2);
       const prNumber = item.number;
 
-      const [ciStatus, reviewsRes, prRes] = await Promise.all([
+      const [ciStatus, reviewsRes, prRes, repoSettings] = await Promise.all([
         getCiStatus(client, owner, repo, `pull/${prNumber}/head`),
         client.pulls
           .listReviews({ owner, repo, pull_number: prNumber })
@@ -162,6 +198,7 @@ export async function fetchPrs(instanceId: string) {
         client.pulls
           .get({ owner, repo, pull_number: prNumber })
           .catch(() => null),
+        getRepoSettings(client, instanceId, owner, repo),
       ]);
 
       const reviews = reviewsRes?.data ?? [];
@@ -184,6 +221,7 @@ export async function fetchPrs(instanceId: string) {
         ciStatus,
         inMergeQueue: mqStatus?.inMergeQueue ?? false,
         autoMerge: mqStatus?.autoMerge ?? false,
+        autoMergeAllowed: repoSettings.autoMergeAllowed,
         headBranch: prData?.head.ref ?? "",
         baseBranch: prData?.base.ref ?? "main",
         reviews: summarizeReviews(reviews),

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -29,6 +29,7 @@ const { cacheStore, configStub, fetchersStub, mockOctokit, octokitHolder } =
           createReview: vi.fn(),
           get: vi.fn(),
           update: vi.fn(),
+          merge: vi.fn(),
           listFiles: vi.fn(),
           listCommits: vi.fn(),
           listReviewComments: vi.fn(),
@@ -317,6 +318,39 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/auto-merge", () => {
       expect.stringContaining("disableAutoMerge"),
       { id: "PR_123" },
     );
+  });
+
+  it("returns 422 with auto_merge_not_allowed when repo disallows it", async () => {
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: { auto_merge: null, node_id: "PR_123" },
+    });
+    mockOctokit.graphql.mockRejectedValue(
+      new Error("Auto merge is not allowed for this repository"),
+    );
+    const res = await call("/github/prs/o/r/5/auto-merge", { method: "POST" });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: "auto_merge_not_allowed" });
+  });
+});
+
+describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
+  it("merges with squash and resyncs prs, reviews, recent-prs", async () => {
+    mockOctokit.pulls.merge.mockResolvedValue({});
+    fetchersStub.fetchPrs.mockResolvedValue([]);
+    fetchersStub.fetchReviews.mockResolvedValue([]);
+    fetchersStub.fetchRecentPrs.mockResolvedValue([]);
+    const res = await call("/github/prs/o/r/5/merge", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(mockOctokit.pulls.merge).toHaveBeenCalledWith({
+      owner: "o",
+      repo: "r",
+      pull_number: 5,
+      merge_method: "squash",
+    });
+    await waitForPendingResyncs();
+    expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
+    expect(fetchersStub.fetchReviews).toHaveBeenCalledWith("github");
+    expect(fetchersStub.fetchRecentPrs).toHaveBeenCalledWith("github");
   });
 });
 

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -352,6 +352,25 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
     expect(fetchersStub.fetchReviews).toHaveBeenCalledWith("github");
     expect(fetchersStub.fetchRecentPrs).toHaveBeenCalledWith("github");
   });
+
+  it("forwards GitHub's first error line when merge is rejected", async () => {
+    const ghErr = Object.assign(new Error("405"), {
+      status: 405,
+      response: {
+        data: {
+          message:
+            "Repository rule violations found\n\nA conversation must be resolved before this pull request can be merged.\n",
+        },
+      },
+    });
+    mockOctokit.pulls.merge.mockRejectedValue(ghErr);
+    const res = await call("/github/prs/o/r/5/merge", { method: "POST" });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error: "merge_rejected",
+      message: "Repository rule violations found",
+    });
+  });
 });
 
 describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -257,15 +257,40 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/auto-merge", async (c) => {
     );
   } else {
     // Enable auto-merge via GraphQL (merge method: squash by default)
-    await client.graphql(
-      `mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { id } } }`,
-      { id: pr.node_id },
-    );
+    try {
+      await client.graphql(
+        `mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { id } } }`,
+        { id: pr.node_id },
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/auto.?merge is not allowed/i.test(msg)) {
+        return c.json({ error: "auto_merge_not_allowed" }, 422);
+      }
+      throw err;
+    }
   }
 
   scheduleResync(instanceId, ["prs"]);
 
   return c.json({ ok: true, autoMerge: !pr.auto_merge });
+});
+
+// Merge a PR directly (squash)
+api.post("/:instanceId/prs/:owner/:repo/:prNumber/merge", async (c) => {
+  const { instanceId, owner, repo, prNumber } = c.req.param();
+  const client = await getClient(instanceId);
+
+  await client.pulls.merge({
+    owner,
+    repo,
+    pull_number: Number(prNumber),
+    merge_method: "squash",
+  });
+
+  scheduleResync(instanceId, ["prs", "reviews", "recent-prs"]);
+
+  return c.json({ ok: true });
 });
 
 // Close a PR

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -281,12 +281,22 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/merge", async (c) => {
   const { instanceId, owner, repo, prNumber } = c.req.param();
   const client = await getClient(instanceId);
 
-  await client.pulls.merge({
-    owner,
-    repo,
-    pull_number: Number(prNumber),
-    merge_method: "squash",
-  });
+  try {
+    await client.pulls.merge({
+      owner,
+      repo,
+      pull_number: Number(prNumber),
+      merge_method: "squash",
+    });
+  } catch (err) {
+    // GitHub returns helpful messages here ("A conversation must be
+    // resolved…", "At least 1 approving review is required…"). Forward
+    // the first line so the toast is actionable.
+    const e = err as { response?: { data?: { message?: string } } };
+    const message =
+      e.response?.data?.message?.split("\n")[0] ?? "Failed to merge PR";
+    return c.json({ error: "merge_rejected", message }, 422);
+  }
 
   scheduleResync(instanceId, ["prs", "reviews", "recent-prs"]);
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -327,24 +327,33 @@ function autoMergeOrFallback(
   queryClient: ReturnType<typeof useQueryClient>,
   item: FocusedItem & { instanceId: string; repo: string; number: number },
 ): void {
-  if (!item.autoMerge) {
-    // Repo doesn't support auto-merge — confirm and merge directly.
-    if (item.autoMergeAllowed === false) {
-      confirmAndMerge(
+  // Disabling auto-merge is the reversal — silent, no confirm.
+  if (item.autoMerge) {
+    mutations
+      .toggleAutoMerge(
         queryClient,
-        item,
-        "Auto-merge is not enabled on this repo. Merge directly?",
-      );
-      return;
-    }
-    // PR is already mergeable now — auto-merge would just merge immediately,
-    // so confirm and merge directly instead.
-    if (isReadyToMergeNow(item)) {
-      confirmAndMerge(queryClient, item, "Merge this PR?");
-      return;
-    }
+        {
+          instanceId: item.instanceId,
+          repo: item.repo,
+          number: item.number,
+        },
+        true,
+      )
+      .catch(() => {});
+    return;
   }
 
+  // PR is mergeable now (or repo doesn't allow auto-merge) — confirm and
+  // merge directly. Either way, the action takes effect immediately.
+  if (item.autoMergeAllowed === false || isReadyToMergeNow(item)) {
+    confirmAndMerge(queryClient, item, "Merge this PR?");
+    return;
+  }
+
+  // PR isn't ready yet — confirm and arm auto-merge so it lands when checks
+  // pass. Confirmation matters because the user is committing to merge once
+  // the gates clear, even if they walk away.
+  if (!confirm("Auto-merge this PR when checks pass?")) return;
   mutations
     .toggleAutoMerge(
       queryClient,
@@ -353,11 +362,11 @@ function autoMergeOrFallback(
         repo: item.repo,
         number: item.number,
       },
-      !!item.autoMerge,
+      false,
     )
     .catch((err) => {
-      // Cache may be stale (allow_auto_merge flipped off after we cached);
-      // keep the runtime fallback as a safety net.
+      // Cache said allow_auto_merge=true but server disagrees — fall through
+      // and merge directly (user already expressed merge intent).
       if (err instanceof AutoMergeNotAllowedError) {
         confirmAndMerge(
           queryClient,
@@ -425,7 +434,7 @@ function getActionsForItem(
         ? "Disable auto-merge"
         : willMergeNow
           ? "Merge"
-          : "Enable auto-merge";
+          : "Auto-merge when ready";
       actions.push({
         label,
         key: "m",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -285,6 +285,7 @@ interface FocusedItem {
   reviews?: { approved: string[]; changesRequested: string[] };
   reviewDecision?: string | null;
   autoMerge?: boolean;
+  autoMergeAllowed?: boolean;
   draft?: boolean;
   notificationId?: string;
   author?: string;
@@ -305,6 +306,22 @@ function autoMergeOrFallback(
   queryClient: ReturnType<typeof useQueryClient>,
   item: FocusedItem & { instanceId: string; repo: string; number: number },
 ): void {
+  // Repo doesn't support auto-merge — confirm and merge directly.
+  if (!item.autoMerge && item.autoMergeAllowed === false) {
+    if (confirm("Auto-merge is not enabled on this repo. Merge directly?")) {
+      mutations
+        .mergePr(queryClient, {
+          instanceId: item.instanceId,
+          repo: item.repo,
+          number: item.number,
+          title: item.title,
+          url: item.url,
+        })
+        .catch(() => {});
+    }
+    return;
+  }
+
   mutations
     .toggleAutoMerge(
       queryClient,
@@ -316,6 +333,8 @@ function autoMergeOrFallback(
       !!item.autoMerge,
     )
     .catch((err) => {
+      // Cache may be stale (allow_auto_merge flipped off after we cached);
+      // keep the runtime fallback as a safety net.
       if (
         err instanceof AutoMergeNotAllowedError &&
         confirm("Auto-merge is not enabled on this repo. Merge directly?")
@@ -383,8 +402,13 @@ function getActionsForItem(
   ) {
     // GitHub rejects enablePullRequestAutoMerge on draft PRs.
     if (item.autoMerge || !item.draft) {
+      const label = item.autoMerge
+        ? "Disable auto-merge"
+        : item.autoMergeAllowed === false
+          ? "Merge"
+          : "Enable auto-merge";
       actions.push({
-        label: item.autoMerge ? "Disable auto-merge" : "Enable auto-merge",
+        label,
         key: "m",
         onSelect: () => {
           autoMergeOrFallback(queryClient, {
@@ -1096,6 +1120,7 @@ function getFocusedItem(
       reviews: p.reviews,
       reviewDecision: p.reviewDecision,
       autoMerge: p.autoMerge,
+      autoMergeAllowed: p.autoMergeAllowed,
       draft: p.draft,
       author: p.author,
       headBranch: p.headBranch,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -302,24 +302,47 @@ interface CommentingPr {
   number: number;
 }
 
+function isReadyToMergeNow(item: FocusedItem): boolean {
+  return item.reviewDecision === "APPROVED" && item.ciStatus === "success";
+}
+
+function confirmAndMerge(
+  queryClient: ReturnType<typeof useQueryClient>,
+  item: FocusedItem & { instanceId: string; repo: string; number: number },
+  message: string,
+): void {
+  if (!confirm(message)) return;
+  mutations
+    .mergePr(queryClient, {
+      instanceId: item.instanceId,
+      repo: item.repo,
+      number: item.number,
+      title: item.title,
+      url: item.url,
+    })
+    .catch(() => {});
+}
+
 function autoMergeOrFallback(
   queryClient: ReturnType<typeof useQueryClient>,
   item: FocusedItem & { instanceId: string; repo: string; number: number },
 ): void {
-  // Repo doesn't support auto-merge — confirm and merge directly.
-  if (!item.autoMerge && item.autoMergeAllowed === false) {
-    if (confirm("Auto-merge is not enabled on this repo. Merge directly?")) {
-      mutations
-        .mergePr(queryClient, {
-          instanceId: item.instanceId,
-          repo: item.repo,
-          number: item.number,
-          title: item.title,
-          url: item.url,
-        })
-        .catch(() => {});
+  if (!item.autoMerge) {
+    // Repo doesn't support auto-merge — confirm and merge directly.
+    if (item.autoMergeAllowed === false) {
+      confirmAndMerge(
+        queryClient,
+        item,
+        "Auto-merge is not enabled on this repo. Merge directly?",
+      );
+      return;
     }
-    return;
+    // PR is already mergeable now — auto-merge would just merge immediately,
+    // so confirm and merge directly instead.
+    if (isReadyToMergeNow(item)) {
+      confirmAndMerge(queryClient, item, "Merge this PR?");
+      return;
+    }
   }
 
   mutations
@@ -335,19 +358,12 @@ function autoMergeOrFallback(
     .catch((err) => {
       // Cache may be stale (allow_auto_merge flipped off after we cached);
       // keep the runtime fallback as a safety net.
-      if (
-        err instanceof AutoMergeNotAllowedError &&
-        confirm("Auto-merge is not enabled on this repo. Merge directly?")
-      ) {
-        mutations
-          .mergePr(queryClient, {
-            instanceId: item.instanceId,
-            repo: item.repo,
-            number: item.number,
-            title: item.title,
-            url: item.url,
-          })
-          .catch(() => {});
+      if (err instanceof AutoMergeNotAllowedError) {
+        confirmAndMerge(
+          queryClient,
+          item,
+          "Auto-merge is not enabled on this repo. Merge directly?",
+        );
       }
     });
 }
@@ -402,9 +418,12 @@ function getActionsForItem(
   ) {
     // GitHub rejects enablePullRequestAutoMerge on draft PRs.
     if (item.autoMerge || !item.draft) {
+      const willMergeNow =
+        !item.autoMerge &&
+        (item.autoMergeAllowed === false || isReadyToMergeNow(item));
       const label = item.autoMerge
         ? "Disable auto-merge"
-        : item.autoMergeAllowed === false
+        : willMergeNow
           ? "Merge"
           : "Enable auto-merge";
       actions.push({

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -284,6 +284,7 @@ interface FocusedItem {
   deletions?: number;
   reviews?: { approved: string[]; changesRequested: string[] };
   reviewDecision?: string | null;
+  mergeStateStatus?: string | null;
   autoMerge?: boolean;
   autoMergeAllowed?: boolean;
   draft?: boolean;
@@ -303,7 +304,11 @@ interface CommentingPr {
 }
 
 function isReadyToMergeNow(item: FocusedItem): boolean {
-  return item.reviewDecision === "APPROVED" && item.ciStatus === "success";
+  // CLEAN means GitHub thinks every gate is satisfied right now (approval,
+  // required checks, conversation resolution, branch up-to-date). Anything
+  // else (BLOCKED, BEHIND, UNSTABLE, DIRTY, …) means a direct merge would
+  // either fail or surprise the user — let auto-merge handle those.
+  return item.mergeStateStatus === "CLEAN";
 }
 
 function confirmAndMerge(
@@ -1147,6 +1152,7 @@ function getFocusedItem(
       deletions: p.deletions,
       reviews: p.reviews,
       reviewDecision: p.reviewDecision,
+      mergeStateStatus: p.mergeStateStatus,
       autoMerge: p.autoMerge,
       autoMergeAllowed: p.autoMergeAllowed,
       draft: p.draft,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,6 +7,11 @@ import { Settings } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AutoMergeNotAllowedError, api, type ConfigResponse } from "./api";
+import {
+  STALE_CACHE_RECOVERY_PROMPT,
+  decideMergeAction,
+  mergeActionLabel,
+} from "./merge-decision";
 import { dismissKey, dismissedReviewsAtom, isDismissed } from "./dismissed";
 import { useChords } from "./use-chords";
 import {
@@ -303,14 +308,6 @@ interface CommentingPr {
   number: number;
 }
 
-function isReadyToMergeNow(item: FocusedItem): boolean {
-  // CLEAN means GitHub thinks every gate is satisfied right now (approval,
-  // required checks, conversation resolution, branch up-to-date). Anything
-  // else (BLOCKED, BEHIND, UNSTABLE, DIRTY, …) means a direct merge would
-  // either fail or surprise the user — let auto-merge handle those.
-  return item.mergeStateStatus === "CLEAN";
-}
-
 function confirmAndMerge(
   queryClient: ReturnType<typeof useQueryClient>,
   item: FocusedItem & { instanceId: string; repo: string; number: number },
@@ -332,54 +329,32 @@ function autoMergeOrFallback(
   queryClient: ReturnType<typeof useQueryClient>,
   item: FocusedItem & { instanceId: string; repo: string; number: number },
 ): void {
-  // Disabling auto-merge is the reversal — silent, no confirm.
-  if (item.autoMerge) {
-    mutations
-      .toggleAutoMerge(
-        queryClient,
-        {
-          instanceId: item.instanceId,
-          repo: item.repo,
-          number: item.number,
-        },
-        true,
-      )
-      .catch(() => {});
+  const decision = decideMergeAction(item);
+  const target = {
+    instanceId: item.instanceId,
+    repo: item.repo,
+    number: item.number,
+  };
+
+  if (decision.kind === "disable_auto_merge") {
+    mutations.toggleAutoMerge(queryClient, target, true).catch(() => {});
     return;
   }
 
-  // PR is mergeable now (or repo doesn't allow auto-merge) — confirm and
-  // merge directly. Either way, the action takes effect immediately.
-  if (item.autoMergeAllowed === false || isReadyToMergeNow(item)) {
-    confirmAndMerge(queryClient, item, "Merge this PR?");
+  if (decision.kind === "merge") {
+    confirmAndMerge(queryClient, item, decision.prompt);
     return;
   }
 
-  // PR isn't ready yet — confirm and arm auto-merge so it lands when checks
-  // pass. Confirmation matters because the user is committing to merge once
-  // the gates clear, even if they walk away.
-  if (!confirm("Auto-merge this PR when checks pass?")) return;
-  mutations
-    .toggleAutoMerge(
-      queryClient,
-      {
-        instanceId: item.instanceId,
-        repo: item.repo,
-        number: item.number,
-      },
-      false,
-    )
-    .catch((err) => {
-      // Cache said allow_auto_merge=true but server disagrees — fall through
-      // and merge directly (user already expressed merge intent).
-      if (err instanceof AutoMergeNotAllowedError) {
-        confirmAndMerge(
-          queryClient,
-          item,
-          "Auto-merge is not enabled on this repo. Merge directly?",
-        );
-      }
-    });
+  // arm_auto_merge
+  if (!confirm(decision.prompt)) return;
+  mutations.toggleAutoMerge(queryClient, target, false).catch((err) => {
+    // Cache said allow_auto_merge=true but server disagrees — fall through
+    // and merge directly (user already expressed merge intent).
+    if (err instanceof AutoMergeNotAllowedError) {
+      confirmAndMerge(queryClient, item, STALE_CACHE_RECOVERY_PROMPT);
+    }
+  });
 }
 
 function getActionsForItem(
@@ -432,16 +407,8 @@ function getActionsForItem(
   ) {
     // GitHub rejects enablePullRequestAutoMerge on draft PRs.
     if (item.autoMerge || !item.draft) {
-      const willMergeNow =
-        !item.autoMerge &&
-        (item.autoMergeAllowed === false || isReadyToMergeNow(item));
-      const label = item.autoMerge
-        ? "Disable auto-merge"
-        : willMergeNow
-          ? "Merge"
-          : "Auto-merge when ready";
       actions.push({
-        label,
+        label: mergeActionLabel(decideMergeAction(item)),
         key: "m",
         onSelect: () => {
           autoMergeOrFallback(queryClient, {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,7 +6,7 @@ import { atomWithStorage } from "jotai/utils";
 import { Settings } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { api, type ConfigResponse } from "./api";
+import { AutoMergeNotAllowedError, api, type ConfigResponse } from "./api";
 import { dismissKey, dismissedReviewsAtom, isDismissed } from "./dismissed";
 import { useChords } from "./use-chords";
 import {
@@ -301,6 +301,38 @@ interface CommentingPr {
   number: number;
 }
 
+function autoMergeOrFallback(
+  queryClient: ReturnType<typeof useQueryClient>,
+  item: FocusedItem & { instanceId: string; repo: string; number: number },
+): void {
+  mutations
+    .toggleAutoMerge(
+      queryClient,
+      {
+        instanceId: item.instanceId,
+        repo: item.repo,
+        number: item.number,
+      },
+      !!item.autoMerge,
+    )
+    .catch((err) => {
+      if (
+        err instanceof AutoMergeNotAllowedError &&
+        confirm("Auto-merge is not enabled on this repo. Merge directly?")
+      ) {
+        mutations
+          .mergePr(queryClient, {
+            instanceId: item.instanceId,
+            repo: item.repo,
+            number: item.number,
+            title: item.title,
+            url: item.url,
+          })
+          .catch(() => {});
+      }
+    });
+}
+
 function getActionsForItem(
   item: FocusedItem,
   queryClient: ReturnType<typeof useQueryClient>,
@@ -355,17 +387,12 @@ function getActionsForItem(
         label: item.autoMerge ? "Disable auto-merge" : "Enable auto-merge",
         key: "m",
         onSelect: () => {
-          mutations
-            .toggleAutoMerge(
-              queryClient,
-              {
-                instanceId: item.instanceId!,
-                repo: item.repo!,
-                number: item.number!,
-              },
-              !!item.autoMerge,
-            )
-            .catch(() => {});
+          autoMergeOrFallback(queryClient, {
+            ...item,
+            instanceId: item.instanceId!,
+            repo: item.repo!,
+            number: item.number!,
+          });
         },
       });
     }
@@ -764,17 +791,12 @@ function Dashboard({ source }: { source: DashboardSource }) {
             toast.error("Mark the PR as ready before enabling auto-merge");
             return;
           }
-          mutations
-            .toggleAutoMerge(
-              queryClient,
-              {
-                instanceId: item.instanceId,
-                repo: item.repo,
-                number: item.number,
-              },
-              !!item.autoMerge,
-            )
-            .catch(() => {});
+          autoMergeOrFallback(queryClient, {
+            ...item,
+            instanceId: item.instanceId,
+            repo: item.repo,
+            number: item.number,
+          });
         }
       } else if (
         e.key === "a" &&

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -143,7 +143,10 @@ export const api = {
         method: "POST",
       },
     );
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.message ?? `${res.status} ${res.statusText}`);
+    }
     return res.json();
   },
   closePr: async (instanceId: string, repo: string, prNumber: number) => {

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -38,6 +38,12 @@ export class ConfigValidationError extends Error {
   }
 }
 
+export class AutoMergeNotAllowedError extends Error {
+  constructor() {
+    super("Auto-merge is not allowed for this repository");
+  }
+}
+
 export const api = {
   getConfig: () => fetchJson<ConfigResponse>("/api/config"),
   saveConfig: async (config: ConfigData) => {
@@ -120,8 +126,25 @@ export const api = {
         method: "POST",
       },
     );
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      if (body?.error === "auto_merge_not_allowed") {
+        throw new AutoMergeNotAllowedError();
+      }
+      throw new Error(`${res.status} ${res.statusText}`);
+    }
     return res.json() as Promise<{ ok: boolean; autoMerge: boolean }>;
+  },
+  mergePr: async (instanceId: string, repo: string, prNumber: number) => {
+    const [owner, name] = repo.split("/");
+    const res = await fetch(
+      `/api/${instanceId}/prs/${owner}/${name}/${prNumber}/merge`,
+      {
+        method: "POST",
+      },
+    );
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.json();
   },
   closePr: async (instanceId: string, repo: string, prNumber: number) => {
     const [owner, name] = repo.split("/");

--- a/packages/web/src/components/PrCard.tsx
+++ b/packages/web/src/components/PrCard.tsx
@@ -203,12 +203,6 @@ export function PrCard({
                   conflict
                 </Pill>
               )}
-              {unresolvedThreadCount != null && unresolvedThreadCount > 0 && (
-                <Pill icon={MessageSquareWarning} tone="amber">
-                  {unresolvedThreadCount} unresolved{" "}
-                  {unresolvedThreadCount === 1 ? "thread" : "threads"}
-                </Pill>
-              )}
               <span className="flex items-center gap-0.5 font-mono">
                 <Text size="small" className="text-green-600">
                   +{additions}
@@ -224,12 +218,24 @@ export function PrCard({
                   {commits}
                 </Text>
               </span>
-              {commentCount > 0 && (
-                <span className="flex items-center gap-1">
-                  <MessageSquare className="h-3 w-3" />
-                  <Text size="small" variant="secondary">
-                    {commentCount}
-                  </Text>
+              {(commentCount > 0 ||
+                (unresolvedThreadCount != null &&
+                  unresolvedThreadCount > 0)) && (
+                <span className="flex items-center gap-2">
+                  {commentCount > 0 && (
+                    <span className="flex items-center gap-1">
+                      <MessageSquare className="h-3 w-3" />
+                      <Text size="small" variant="secondary">
+                        {commentCount}
+                      </Text>
+                    </span>
+                  )}
+                  {unresolvedThreadCount != null &&
+                    unresolvedThreadCount > 0 && (
+                      <Pill icon={MessageSquareWarning} tone="amber">
+                        {unresolvedThreadCount} unresolved
+                      </Pill>
+                    )}
                 </span>
               )}
             </div>

--- a/packages/web/src/components/PrCard.tsx
+++ b/packages/web/src/components/PrCard.tsx
@@ -119,43 +119,12 @@ export function PrCard({
           : ""
       }`}
     >
-      <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
-        {reviews.approved.length > 0 && (
-          <ReviewStamp kind="approved" count={reviews.approved.length} />
-        )}
-        {reviews.changesRequested.length > 0 && (
-          <ReviewStamp
-            kind="changes-requested"
-            count={reviews.changesRequested.length}
-          />
-        )}
-        {reviewDecision === "REVIEW_REQUIRED" &&
-          reviews.approved.length > 0 && (
-            <ReviewStamp kind="missing-code-owner" />
-          )}
-      </div>
-      <div className="absolute bottom-2 right-2 flex flex-col items-end gap-0.5">
-        {createdAt && (
-          <span className="flex items-center gap-1">
-            <Text size="small" variant="tertiary" className="text-[10px]">
-              opened
-            </Text>
-            <TimeAgo date={createdAt} className="text-[10px]" />
-          </span>
-        )}
-        <span className="flex items-center gap-1">
-          <Text size="small" variant="tertiary" className="text-[10px]">
-            updated
-          </Text>
-          <TimeAgo date={updatedAt} className="text-[10px]" />
-        </span>
-      </div>
       <div className="flex">
         <div className="flex shrink-0 items-center justify-center pr-4">
           <PrStateIcon status={mergeStatus} loading={loading} />
         </div>
-        <div className="flex-1 overflow-hidden pr-32">
-          <div className="flex items-center gap-2 whitespace-nowrap">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
             {instanceId && (
               <span
                 className="h-2 w-2 shrink-0 rounded-full"
@@ -166,7 +135,7 @@ export function PrCard({
             <Text size="small" variant="secondary" className="truncate">
               {repo}
             </Text>
-            <Text size="small" variant="tertiary">
+            <Text size="small" variant="tertiary" className="shrink-0">
               #{number}
             </Text>
             {author && (
@@ -174,6 +143,21 @@ export function PrCard({
                 @{author}
               </Text>
             )}
+            <div className="ml-auto flex shrink-0 items-center gap-1">
+              {reviews.approved.length > 0 && (
+                <ReviewStamp kind="approved" count={reviews.approved.length} />
+              )}
+              {reviews.changesRequested.length > 0 && (
+                <ReviewStamp
+                  kind="changes-requested"
+                  count={reviews.changesRequested.length}
+                />
+              )}
+              {reviewDecision === "REVIEW_REQUIRED" &&
+                reviews.approved.length > 0 && (
+                  <ReviewStamp kind="missing-code-owner" />
+                )}
+            </div>
           </div>
           {editing ? (
             <input
@@ -250,22 +234,43 @@ export function PrCard({
               )}
             </div>
           )}
-          {!merged &&
-            (() => {
-              const ci = toCiStatus(ciStatus);
-              const anyBadge = ci || autoMerge;
-              if (!anyBadge) return null;
-              return (
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  {ci && <StatusBadge status={ci} />}
-                  {autoMerge && (
-                    <Pill icon={Rocket} tone="green">
-                      auto-merge
-                    </Pill>
+          {(() => {
+            const ci = !merged && toCiStatus(ciStatus);
+            return (
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {ci && <StatusBadge status={ci} />}
+                {!merged && autoMerge && (
+                  <Pill icon={Rocket} tone="green">
+                    auto-merge
+                  </Pill>
+                )}
+                <div className="ml-auto flex items-center gap-3 text-muted-foreground">
+                  {createdAt && (
+                    <span className="flex items-center gap-1">
+                      <Text
+                        size="small"
+                        variant="tertiary"
+                        className="text-[10px]"
+                      >
+                        opened
+                      </Text>
+                      <TimeAgo date={createdAt} className="text-[10px]" />
+                    </span>
                   )}
+                  <span className="flex items-center gap-1">
+                    <Text
+                      size="small"
+                      variant="tertiary"
+                      className="text-[10px]"
+                    >
+                      updated
+                    </Text>
+                    <TimeAgo date={updatedAt} className="text-[10px]" />
+                  </span>
                 </div>
-              );
-            })()}
+              </div>
+            );
+          })()}
         </div>
       </div>
     </Card>

--- a/packages/web/src/components/PrCard.tsx
+++ b/packages/web/src/components/PrCard.tsx
@@ -233,7 +233,8 @@ export function PrCard({
                   {unresolvedThreadCount != null &&
                     unresolvedThreadCount > 0 && (
                       <Pill icon={MessageSquareWarning} tone="amber">
-                        {unresolvedThreadCount} unresolved
+                        {unresolvedThreadCount} open{" "}
+                        {unresolvedThreadCount === 1 ? "thread" : "threads"}
                       </Pill>
                     )}
                 </span>

--- a/packages/web/src/components/PrCard.tsx
+++ b/packages/web/src/components/PrCard.tsx
@@ -218,26 +218,20 @@ export function PrCard({
                   {commits}
                 </Text>
               </span>
-              {(commentCount > 0 ||
-                (unresolvedThreadCount != null &&
-                  unresolvedThreadCount > 0)) && (
-                <span className="flex items-center gap-2">
-                  {commentCount > 0 && (
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="h-3 w-3" />
-                      <Text size="small" variant="secondary">
-                        {commentCount}
-                      </Text>
-                    </span>
-                  )}
-                  {unresolvedThreadCount != null &&
-                    unresolvedThreadCount > 0 && (
-                      <Pill icon={MessageSquareWarning} tone="amber">
-                        {unresolvedThreadCount} open{" "}
-                        {unresolvedThreadCount === 1 ? "thread" : "threads"}
-                      </Pill>
-                    )}
-                </span>
+              {unresolvedThreadCount != null && unresolvedThreadCount > 0 ? (
+                <Pill icon={MessageSquareWarning} tone="amber">
+                  {unresolvedThreadCount} open{" "}
+                  {unresolvedThreadCount === 1 ? "thread" : "threads"}
+                </Pill>
+              ) : (
+                commentCount > 0 && (
+                  <span className="flex items-center gap-1">
+                    <MessageSquare className="h-3 w-3" />
+                    <Text size="small" variant="secondary">
+                      {commentCount}
+                    </Text>
+                  </span>
+                )
               )}
             </div>
           )}

--- a/packages/web/src/components/PrCard.tsx
+++ b/packages/web/src/components/PrCard.tsx
@@ -8,6 +8,7 @@ import {
   GitBranch,
   GitCommit,
   MessageSquare,
+  MessageSquareWarning,
   Rocket,
   TriangleAlert,
 } from "lucide-react";
@@ -46,6 +47,7 @@ interface Props {
   editing?: boolean;
   onSaveTitle?: (title: string) => void;
   conflict?: boolean;
+  unresolvedThreadCount?: number;
 }
 
 export function PrCard({
@@ -75,6 +77,7 @@ export function PrCard({
   editing,
   onSaveTitle,
   conflict,
+  unresolvedThreadCount,
 }: Props) {
   const merged = mergeStatus === "merged";
   const [editTitle, setEditTitle] = useState(title);
@@ -214,6 +217,12 @@ export function PrCard({
               {conflict && (
                 <Pill icon={TriangleAlert} tone="red">
                   conflict
+                </Pill>
+              )}
+              {unresolvedThreadCount != null && unresolvedThreadCount > 0 && (
+                <Pill icon={MessageSquareWarning} tone="amber">
+                  {unresolvedThreadCount} unresolved{" "}
+                  {unresolvedThreadCount === 1 ? "thread" : "threads"}
                 </Pill>
               )}
               <span className="flex items-center gap-0.5 font-mono">

--- a/packages/web/src/components/PrCardPlayground.tsx
+++ b/packages/web/src/components/PrCardPlayground.tsx
@@ -26,6 +26,7 @@ export function PrCardPlayground() {
   const [mergeStatus, setMergeStatus] = useState<MergeStatus>("ready");
   const [autoMerge, setAutoMerge] = useState(true);
   const [conflict, setConflict] = useState(false);
+  const [unresolvedThreadCount, setUnresolvedThreadCount] = useState(0);
   const [instanceId, setInstanceId] = useState("github.com");
   const [focused, setFocused] = useState(true);
   const [editing, setEditing] = useState(false);
@@ -52,6 +53,17 @@ export function PrCardPlayground() {
           onChange={setAutoMerge}
         />
         <Toggle label="Conflict" checked={conflict} onChange={setConflict} />
+        <Field label="Unresolved threads">
+          <input
+            type="number"
+            min={0}
+            value={unresolvedThreadCount}
+            onChange={(e) =>
+              setUnresolvedThreadCount(Math.max(0, +e.target.value))
+            }
+            className={inputCls}
+          />
+        </Field>
         <Toggle label="Focused" checked={focused} onChange={setFocused} />
         <Toggle label="Editing title" checked={editing} onChange={setEditing} />
 
@@ -243,6 +255,7 @@ export function PrCardPlayground() {
             author={author || undefined}
             editing={editing}
             conflict={conflict}
+            unresolvedThreadCount={unresolvedThreadCount}
             onSaveTitle={(t) => {
               if (t) setTitle(t);
               setEditing(false);

--- a/packages/web/src/components/PrList.tsx
+++ b/packages/web/src/components/PrList.tsx
@@ -62,6 +62,7 @@ export function PrList({
                 commits={pr.commits}
                 commentCount={pr.commentCount}
                 conflict={pr.mergeable === false}
+                unresolvedThreadCount={pr.unresolvedThreadCount}
                 focused={focused}
                 instanceId={pr.instanceId}
                 instanceLabel={pr.instanceLabel}

--- a/packages/web/src/merge-decision.test.ts
+++ b/packages/web/src/merge-decision.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  type MergeInput,
+  decideMergeAction,
+  mergeActionLabel,
+} from "./merge-decision";
+
+describe("decideMergeAction", () => {
+  it("disables auto-merge when it's currently armed (other fields ignored)", () => {
+    const cases: MergeInput[] = [
+      { autoMerge: true },
+      { autoMerge: true, autoMergeAllowed: false },
+      { autoMerge: true, mergeStateStatus: "BLOCKED" },
+      { autoMerge: true, autoMergeAllowed: true, mergeStateStatus: "CLEAN" },
+    ];
+    for (const c of cases) {
+      expect(decideMergeAction(c)).toEqual({ kind: "disable_auto_merge" });
+    }
+  });
+
+  it("merges directly when the repo doesn't allow auto-merge", () => {
+    expect(
+      decideMergeAction({
+        autoMergeAllowed: false,
+        mergeStateStatus: "BLOCKED",
+      }),
+    ).toEqual({ kind: "merge", prompt: "Merge this PR?" });
+  });
+
+  it("merges directly when mergeStateStatus is CLEAN", () => {
+    expect(
+      decideMergeAction({ autoMergeAllowed: true, mergeStateStatus: "CLEAN" }),
+    ).toEqual({ kind: "merge", prompt: "Merge this PR?" });
+  });
+
+  it("prefers direct merge over arm when both repo disallows auto-merge AND state is CLEAN", () => {
+    // Same outcome as either branch alone — but verifies precedence is stable.
+    expect(
+      decideMergeAction({ autoMergeAllowed: false, mergeStateStatus: "CLEAN" }),
+    ).toEqual({ kind: "merge", prompt: "Merge this PR?" });
+  });
+
+  it("arms auto-merge when the PR has open work (BLOCKED, BEHIND, UNSTABLE, etc.)", () => {
+    for (const status of [
+      "BLOCKED",
+      "BEHIND",
+      "UNSTABLE",
+      "DIRTY",
+      "UNKNOWN",
+    ]) {
+      expect(
+        decideMergeAction({ autoMergeAllowed: true, mergeStateStatus: status }),
+      ).toEqual({
+        kind: "arm_auto_merge",
+        prompt: "Auto-merge this PR when checks pass?",
+      });
+    }
+  });
+
+  it("arms auto-merge when repo settings are unknown and state isn't CLEAN", () => {
+    // autoMergeAllowed undefined (cache miss) + non-CLEAN state — fall through
+    // to arming and let the runtime 422 fallback handle stale-cache cases.
+    expect(decideMergeAction({ mergeStateStatus: "BLOCKED" })).toEqual({
+      kind: "arm_auto_merge",
+      prompt: "Auto-merge this PR when checks pass?",
+    });
+  });
+
+  it("treats undefined autoMerge as off (falsy)", () => {
+    expect(
+      decideMergeAction({ autoMergeAllowed: true, mergeStateStatus: "CLEAN" }),
+    ).toEqual({ kind: "merge", prompt: "Merge this PR?" });
+  });
+});
+
+describe("mergeActionLabel", () => {
+  it("labels each decision kind", () => {
+    expect(mergeActionLabel({ kind: "disable_auto_merge" })).toBe(
+      "Disable auto-merge",
+    );
+    expect(mergeActionLabel({ kind: "merge", prompt: "x" })).toBe("Merge");
+    expect(mergeActionLabel({ kind: "arm_auto_merge", prompt: "x" })).toBe(
+      "Auto-merge when ready",
+    );
+  });
+});

--- a/packages/web/src/merge-decision.ts
+++ b/packages/web/src/merge-decision.ts
@@ -1,0 +1,45 @@
+// Pure decision logic for what pressing M on a PR should do.
+// Kept free of React/DOM/mutation concerns so the branches are unit-testable;
+// callers (App.tsx) translate the decision into confirm() + mutation calls.
+
+export interface MergeInput {
+  autoMerge?: boolean;
+  autoMergeAllowed?: boolean;
+  // GraphQL mergeStateStatus; CLEAN means every gate is satisfied right now.
+  mergeStateStatus?: string | null;
+}
+
+export type MergeDecision =
+  | { kind: "disable_auto_merge" }
+  | { kind: "merge"; prompt: string }
+  | { kind: "arm_auto_merge"; prompt: string };
+
+export const STALE_CACHE_RECOVERY_PROMPT =
+  "Auto-merge is not enabled on this repo. Merge directly?";
+
+export function decideMergeAction(item: MergeInput): MergeDecision {
+  // Disabling auto-merge is the reversal — caller treats this as silent.
+  if (item.autoMerge) return { kind: "disable_auto_merge" };
+
+  // Repo can't auto-merge, or PR is mergeable now — direct merge.
+  if (item.autoMergeAllowed === false || item.mergeStateStatus === "CLEAN") {
+    return { kind: "merge", prompt: "Merge this PR?" };
+  }
+
+  // PR has open work — arm auto-merge so it lands when checks pass.
+  return {
+    kind: "arm_auto_merge",
+    prompt: "Auto-merge this PR when checks pass?",
+  };
+}
+
+export function mergeActionLabel(decision: MergeDecision): string {
+  switch (decision.kind) {
+    case "disable_auto_merge":
+      return "Disable auto-merge";
+    case "merge":
+      return "Merge";
+    case "arm_auto_merge":
+      return "Auto-merge when ready";
+  }
+}

--- a/packages/web/src/mutations.ts
+++ b/packages/web/src/mutations.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { api } from "./api";
+import { AutoMergeNotAllowedError, api } from "./api";
 import type { Notification, PR, RecentPR, ReviewRequest } from "./types";
 
 interface Target {
@@ -60,7 +60,48 @@ export async function toggleAutoMerge(
     await api.toggleAutoMerge(target.instanceId, target.repo, target.number);
   } catch (err) {
     restore(qc, snap);
-    toast.error("Failed to toggle auto-merge");
+    if (!(err instanceof AutoMergeNotAllowedError)) {
+      toast.error("Failed to toggle auto-merge");
+    }
+    throw err;
+  }
+}
+
+export async function mergePr(
+  qc: QueryClient,
+  target: Target & { title: string; url: string },
+): Promise<void> {
+  const prsSnap = snapshot<PR[]>(qc, "prs");
+  const reviewsSnap = snapshot<ReviewRequest[]>(qc, "reviews");
+  const recentSnap = snapshot<RecentPR[]>(qc, "recent-prs");
+
+  qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
+    old?.filter((pr) => !matches(target)(pr)),
+  );
+  qc.setQueriesData<ReviewRequest[]>({ queryKey: ["reviews"] }, (old) =>
+    old?.filter((r) => !matches(target)(r)),
+  );
+  qc.setQueriesData<RecentPR[]>({ queryKey: ["recent-prs"] }, (old) => [
+    {
+      id: Date.now(),
+      number: target.number,
+      title: target.title,
+      url: target.url,
+      repo: target.repo,
+      updatedAt: new Date().toISOString(),
+      merged: true,
+    },
+    ...(old ?? []),
+  ]);
+
+  try {
+    await api.mergePr(target.instanceId, target.repo, target.number);
+    toast.success("PR merged");
+  } catch (err) {
+    restore(qc, prsSnap);
+    restore(qc, reviewsSnap);
+    restore(qc, recentSnap);
+    toast.error("Failed to merge PR");
     throw err;
   }
 }

--- a/packages/web/src/mutations.ts
+++ b/packages/web/src/mutations.ts
@@ -101,7 +101,7 @@ export async function mergePr(
     restore(qc, prsSnap);
     restore(qc, reviewsSnap);
     restore(qc, recentSnap);
-    toast.error("Failed to merge PR");
+    toast.error(err instanceof Error ? err.message : "Failed to merge PR");
     throw err;
   }
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -20,6 +20,7 @@ export interface PR {
   ciStatus: string;
   inMergeQueue: boolean;
   autoMerge: boolean;
+  autoMergeAllowed?: boolean;
   headBranch: string;
   baseBranch: string;
   reviews: { approved: string[]; changesRequested: string[] };

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -25,6 +25,7 @@ export interface PR {
   baseBranch: string;
   reviews: { approved: string[]; changesRequested: string[] };
   reviewDecision?: string | null;
+  mergeStateStatus?: string | null;
   additions: number;
   deletions: number;
   commits: number;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -26,6 +26,7 @@ export interface PR {
   reviews: { approved: string[]; changesRequested: string[] };
   reviewDecision?: string | null;
   mergeStateStatus?: string | null;
+  unresolvedThreadCount?: number;
   additions: number;
   deletions: number;
   commits: number;
@@ -56,6 +57,7 @@ export interface ReviewRequest {
   baseBranch: string;
   reviews: { approved: string[]; changesRequested: string[] };
   reviewDecision?: string | null;
+  unresolvedThreadCount?: number;
   additions: number;
   deletions: number;
   commits: number;


### PR DESCRIPTION
## Summary

Pressing **M** on a PR now follows a single mental model: head toward merge, with confirmation. The system picks the mechanism based on PR state.

| State | M does |
| --- | --- |
| Auto-merge already enabled | Disable, silent (reversal) |
| Mergeable now (approved + green CI), or repo doesn't allow auto-merge | Confirm `"Merge this PR?"` → squash-merge directly |
| Otherwise | Confirm `"Auto-merge this PR when checks pass?"` → arm auto-merge |

Repo-level `allow_auto_merge` is fetched once per repo (deduped, disk-cached) and shipped as `autoMergeAllowed` on each PR, so M can branch up front without a roundtrip. A 422 fallback handles stale-cache cases (cached `true`, server now `false`).

## Why
- Previously M silently flipped auto-merge and gave a generic "Failed to toggle auto-merge" toast when the repo didn't allow it (e.g. AntonNiklasson/github-dashboard had `allow_auto_merge=false`).
- For approved + green PRs, enabling auto-merge would just merge immediately — pressing M with no confirmation was a footgun.
- Both "merge directly" and "arm auto-merge" commit the user to a merge outcome, so both confirm. Disabling auto-merge is the only path that stays silent.

## Test plan
- [ ] Repo with auto-merge disabled, PR not yet ready → action label `"Merge"`, M prompts confirm, accepting merges
- [ ] Repo with auto-merge enabled, PR approved + green → action label `"Merge"`, M prompts confirm, accepting merges immediately
- [ ] Repo with auto-merge enabled, PR pending CI → action label `"Auto-merge when ready"`, M prompts confirm, accepting arms auto-merge
- [ ] PR currently auto-merging → action label `"Disable auto-merge"`, M disables silently (no confirm)
- [ ] Server-side cache survives restart, second M press in same repo doesn't refetch settings