### PR TITLE
neutralize draft-PR toast wording

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -812,7 +812,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
         if (item?.repo && item.number && item.instanceId && !item.readOnly) {
           e.preventDefault();
           if (!item.autoMerge && item.draft) {
-            toast.error("Mark the PR as ready before enabling auto-merge");
+            toast.error("Mark the PR as ready before merging");
             return;
           }
           autoMergeOrFallback(queryClient, {


### PR DESCRIPTION
## Summary
- After PR #21 unified the **M** action so it can mean either "merge directly" or "arm auto-merge", the draft-PR guard's toast still said "before enabling auto-merge"
- Reword to "before merging" since the gate blocks both branches (GitHub disallows merging drafts either way)

## Test plan
- [ ] Press **M** on a draft PR → toast reads "Mark the PR as ready before merging"