### PR TITLE
tee dev stdout to .logs/{server,web}.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 **/dist/
 config.yaml
 .cache/
+.logs/
 *.tsbuildinfo
 pnpm-debug.log*
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent notes
+
+## Dev logs
+
+When `pnpm dev` is running, server and web stdout/stderr are tee'd to:
+
+- `.logs/server.log` — `tsx watch src/index.ts`
+- `.logs/web.log` — `vite`
+
+Tail or read these files to inspect dev output. Logs reset on each `pnpm dev` start; accumulate across hot reloads within a session.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.29.3",
   "scripts": {
-    "dev": "concurrently -n server,web -c blue,green \"pnpm --filter @github-dashboard/server dev\" \"pnpm --filter @github-dashboard/web dev\"",
+    "dev": "mkdir -p .logs && concurrently -n server,web -c blue,green \"pnpm --filter @github-dashboard/server dev 2>&1 | tee .logs/server.log\" \"pnpm --filter @github-dashboard/web dev 2>&1 | tee .logs/web.log\"",
     "demo": "DEMO=1 pnpm dev",
     "build": "pnpm --filter @github-dashboard/server build && pnpm --filter @github-dashboard/web build",
     "lint": "oxlint",


### PR DESCRIPTION
## Summary
- `pnpm dev` now tees each process's stdout/stderr to `.logs/server.log` and `.logs/web.log`
- Lets Claude (and the user) inspect dev output without copy/pasting from a terminal
- Logs reset per `pnpm dev` start, accumulate across hot reloads within a session
- `.logs/` is gitignored

## Test plan
- [ ] `pnpm dev` writes to `.logs/server.log` and `.logs/web.log` while still printing to terminal via concurrently