### PR TITLE
add Playwright MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config.yaml
 *.tsbuildinfo
 pnpm-debug.log*
 .claude/settings.local.json
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--isolated"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,26 @@
 # Agent notes
 
-## Dev logs
+Monorepo: `packages/server` (Hono API, port 7100) + `packages/web` (Vite/React, port 7200, proxies `/api` to server).
 
-When `pnpm dev` is running, server and web stdout/stderr are tee'd to:
+## Validating your own work
 
-- `.logs/server.log` — `tsx watch src/index.ts`
-- `.logs/web.log` — `vite`
+Close the loop before declaring done. Available tools:
 
-Tail or read these files to inspect dev output. Logs reset on each `pnpm dev` start; accumulate across hot reloads within a session.
+- `pnpm typecheck` — TS across both packages
+- `pnpm test` — vitest in both packages
+- `pnpm lint` — oxlint
+- `pnpm fmt:check` — oxfmt
+- `pnpm dev` — runs server + web concurrently (long-running; start in background). Stdout/stderr is tee'd to `.logs/server.log` and `.logs/web.log` — tail or read these to inspect output. Logs reset on each start; accumulate across hot reloads within a session.
+
+For UI/UX changes, type-checks aren't enough — drive the app via the **Playwright MCP** (`.mcp.json`):
+
+- `browser_navigate` to `http://localhost:7200`
+- `browser_snapshot` for the accessibility tree (preferred over screenshots for assertions)
+- `browser_click`, `browser_type`, `browser_press_key` to exercise keyboard shortcuts
+- `browser_console_messages` to catch runtime errors
+- `browser_network_requests` to verify `/api/*` calls
+- `browser_take_screenshot` only when visual confirmation is needed
+
+Typical loop: edit → dev server hot-reloads → snapshot/interact → check console + `.logs/*` → iterate.
+
+A `config.yaml` with valid tokens already exists locally; don't overwrite it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Adds project-scoped `.mcp.json` so Claude Code sessions in this repo can use Playwright MCP
- Lets Claude take browser screenshots and interact with the running dev app at localhost — closes the UI feedback loop where Claude couldn't previously verify visual changes
- `--isolated` keeps it from touching the persistent browser profile

## Activation
After merging, restart Claude Code in this repo. It'll prompt to approve the MCP server. Once approved, tools like `browser_navigate`, `browser_snapshot`, `browser_take_screenshot`, `browser_click` are available.

## Test plan
- [ ] Restart Claude Code → approval prompt for `playwright` server appears
- [ ] After approval, `/mcp` lists `playwright` as connected