### PR TITLE
react to OS theme changes in real time

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -93,6 +93,7 @@ export function App() {
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [theme] = useAtom(themeAtom);
+
   useEffect(() => {
     applyTheme(theme);
     if (theme !== "system") return;
@@ -101,6 +102,7 @@ export function App() {
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
   }, [theme]);
+
   useEffect(() => {
     const hideCursorOnKeyboard = () => {
       if (!document.querySelector('[data-has-moved="true"]')) return;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -93,7 +93,14 @@ export function App() {
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [theme] = useAtom(themeAtom);
-  useEffect(() => applyTheme(theme), [theme]);
+  useEffect(() => {
+    applyTheme(theme);
+    if (theme !== "system") return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme(theme);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [theme]);
   useEffect(() => {
     const hideCursorOnKeyboard = () => {
       if (!document.querySelector('[data-has-moved="true"]')) return;


### PR DESCRIPTION
Closes #27.

Subscribe to `prefers-color-scheme` changes when `theme=system` so the
dashboard re-themes immediately, instead of only on initial load.

## Test plan
- [ ] With theme set to System, toggle macOS appearance — dashboard switches light/dark without reload.
- [ ] With theme set to Light or Dark, OS toggle has no effect.