### PR TITLE
fix disable auto-merge mutation name

### DIFF
--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -318,7 +318,7 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/auto-merge", () => {
     const res = await call("/github/prs/o/r/5/auto-merge", { method: "POST" });
     expect(await res.json()).toEqual({ ok: true, autoMerge: false });
     expect(mockOctokit.graphql).toHaveBeenCalledWith(
-      expect.stringContaining("disableAutoMerge"),
+      expect.stringContaining("disablePullRequestAutoMerge"),
       { id: "PR_123" },
     );
   });

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -272,7 +272,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/auto-merge", async (c) => {
   if (pr.auto_merge) {
     // Disable auto-merge via GraphQL
     await client.graphql(
-      `mutation($id: ID!) { disableAutoMerge(input: { pullRequestId: $id }) { pullRequest { id } } }`,
+      `mutation($id: ID!) { disablePullRequestAutoMerge(input: { pullRequestId: $id }) { pullRequest { id } } }`,
       { id: pr.node_id },
     );
   } else {


### PR DESCRIPTION
## Summary
- The GitHub GraphQL mutation for disabling auto-merge is `disablePullRequestAutoMerge`, not `disableAutoMerge`. Toggling auto-merge off errored with `Field 'disableAutoMerge' doesn't exist on type 'Mutation'`.
- Fix the mutation name and update the existing test assertion.

## Test plan
- [x] `pnpm test` passes
- [ ] Toggle auto-merge off on a real PR in the UI