### PR TITLE
desktop-release: fix bump job (drop pnpm cache, trace script)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -37,12 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Configure git
         run: |
@@ -53,6 +50,7 @@ jobs:
         id: bump
         working-directory: packages/desktop
         run: |
+          set -x
           mode="${{ inputs.mode }}"
           current=$(node -p "require('./package.json').version")
           if [ "$mode" = "rc" ]; then


### PR DESCRIPTION
The desktop release workflow's bump job set `cache: pnpm` on `setup-node` but never runs `pnpm install`, so the post-step errored on save and marked the whole job failed — gating the build job on `bump.result == 'success'` then skipped it. Last rc run: [26023193582](https://github.com/AntonNiklasson/github-dashboard/actions/runs/26023193582).

## Changes
- Drop `pnpm/action-setup@v4` and `cache: pnpm` from the bump job (it only needs `node` for `npm version`).
- Add `set -x` at the top of the bump script — last run had zero captured stdout and `git push --follow-tags` reported "Everything up-to-date" without any tag landing on the remote, so the next run will leave a trace.

## Test plan
- [ ] Merge, then trigger Desktop Release → rc and confirm the bump job no longer fails post-cleanup.
- [ ] Confirm `set -x` output shows what `npm version` is actually doing if no commit is pushed again.