### PR TITLE
desktop-release: push bump via admin PAT

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -35,7 +35,13 @@ jobs:
     outputs:
       ref: ${{ steps.bump.outputs.ref }}
     steps:
+      # Use a PAT for checkout so the push from this job can bypass the
+      # "main requires PR" ruleset. The GITHUB_TOKEN identity (github-actions[bot])
+      # can't be added as a bypass actor on personal repos; the PAT belongs to
+      # the repo admin, who is whitelisted via RepositoryRole bypass.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
GITHUB_TOKEN can't bypass the "main requires PR" ruleset on personal repos. Use a fine-grained PAT (`RELEASE_TOKEN`) for the bump job's `actions/checkout` so the subsequent push runs as the repo admin, who has RepositoryRole bypass on the ruleset.

## Setup before merging
1. Create a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new): scope to `AntonNiklasson/github-dashboard`, give it `Contents: Read and write`, expiry ~1y.
2. Add it as a repo secret named `RELEASE_TOKEN` in [Settings → Secrets → Actions](https://github.com/AntonNiklasson/github-dashboard/settings/secrets/actions).

## Test plan
- [ ] Merge, then trigger Desktop Release → rc and confirm the push lands the bump commit on main and the tag.