### PR TITLE
desktop-release: build job contents: write for release publish

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -95,6 +95,10 @@ jobs:
     # Run when bump succeeded (workflow_dispatch) or was skipped (tag push).
     if: ${{ always() && (needs.bump.result == 'success' || needs.bump.result == 'skipped') }}
     runs-on: macos-latest
+    permissions:
+      # electron-builder POSTs to /releases via GITHUB_TOKEN; default
+      # job perms are read-only and 403 on that call.
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Last rc run [26025889274](https://github.com/AntonNiklasson/github-dashboard/actions/runs/26025889274) — bump + tag landed, build packaged successfully, but publish 403'd: electron-builder POSTs to `/repos/.../releases` via `GITHUB_TOKEN` and the build job had no `permissions:` block, defaulting to read-only.

Grant `contents: write` on the build job; bump already has it.

## Test plan
- [ ] Trigger Desktop Release → rc, confirm publish step succeeds and a pre-release shows up at https://github.com/AntonNiklasson/github-dashboard/releases.