### PR TITLE
desktop-release: publish draft first, promote to pre-release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -119,18 +119,12 @@ jobs:
 
       - run: pnpm --filter @github-dashboard/desktop build
 
-      - name: Package + publish (pre-release)
-        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'rc'
-        # Override the package.json publish.releaseType (default: draft) so the
-        # rc release is created as a real GitHub pre-release. electron-updater
-        # ignores pre-releases by default; clients opt in to consume them.
-        run: pnpm --filter @github-dashboard/desktop package --publish always --config.publish.releaseType=prerelease
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
-
-      - name: Package + publish (draft release)
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'release')
+      # Always publish to a draft first. GitHub's immutable-releases behavior
+      # locks published releases (including pre-releases) against further
+      # changes, so creating one straight as pre-release breaks the
+      # create-then-upload-assets sequence electron-builder uses. Drafts are
+      # mutable; the promote step below flips it to pre-release after uploads.
+      - name: Package + publish (draft)
         run: pnpm --filter @github-dashboard/desktop package --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -138,3 +132,9 @@ jobs:
           # ship unsigned. macOS users will need to right-click → Open the first
           # time.
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Promote draft to pre-release (rc mode)
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'rc'
+        run: gh release edit "${{ needs.bump.outputs.ref }}" --draft=false --prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Last rc run [26026119553](https://github.com/AntonNiklasson/github-dashboard/actions/runs/26026119553): build succeeded, but `Package + publish` 422'd on every asset upload — `Cannot upload assets to an immutable release`. GitHub now marks new published releases (including pre-releases) immutable on creation, so electron-builder's create-release-then-upload-assets flow breaks.

Fix:
- Always publish to a draft (mutable) — `pnpm package --publish always` uses the package.json `releaseType: "draft"` default.
- In rc mode, post-build, flip the draft to a real pre-release with `gh release edit --draft=false --prerelease`.
- `release` mode keeps existing behavior (draft stays for manual review/publish).

Side note: leaves the empty `v0.0.1-rc.1` ghost release from the failed run in place. Next rc will produce `v0.0.1-rc.2`; rc.1 ghost can be deleted manually later (immutable releases can still be deleted by admins).

## Test plan
- [ ] Trigger Desktop Release → rc, confirm a real pre-release with .dmg/.zip assets appears at https://github.com/AntonNiklasson/github-dashboard/releases.