### PR TITLE
desktop: in-app update-available notice (hourly poll + dev simulate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "mkdir -p .logs && concurrently -n server,web -c blue,green \"pnpm --filter @github-dashboard/server dev 2>&1 | tee .logs/server.log\" \"pnpm --filter @github-dashboard/web dev 2>&1 | tee .logs/web.log\"",
     "dev:desktop": "mkdir -p .logs && pnpm --filter @github-dashboard/desktop build && concurrently -n server,web,desktop -c blue,green,magenta \"pnpm --filter @github-dashboard/server dev 2>&1 | tee .logs/server.log\" \"pnpm --filter @github-dashboard/web dev 2>&1 | tee .logs/web.log\" \"wait-on http://localhost:7200 && pnpm --filter @github-dashboard/desktop dev 2>&1 | tee .logs/desktop.log\"",
     "demo": "DEMO=1 pnpm dev",
+    "demo:desktop": "DEMO=1 pnpm dev:desktop",
     "build": "pnpm --filter @github-dashboard/server build && pnpm --filter @github-dashboard/web build",
     "build:desktop": "pnpm build && pnpm --filter @github-dashboard/desktop build && pnpm --filter @github-dashboard/desktop package",
     "lint": "oxlint",

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, app, shell } from "electron";
+import { BrowserWindow, Menu, Notification, app, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import { autoUpdater } from "electron-updater";
 import net from "node:net";
@@ -83,6 +83,38 @@ async function createWindow(): Promise<void> {
   }
 }
 
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+function setupAutoUpdater(): void {
+  // Notify once per downloaded version. If the user dismisses the OS
+  // notification we don't re-pop it on the next hourly check; a newer
+  // version (different `info.version`) will produce a fresh notification.
+  const notifiedVersions = new Set<string>();
+
+  autoUpdater.on("update-downloaded", (info) => {
+    if (notifiedVersions.has(info.version)) return;
+    notifiedVersions.add(info.version);
+    const notification = new Notification({
+      title: "Update ready",
+      body: `Version ${info.version} is ready. Click to restart and install.`,
+    });
+    notification.on("click", () => autoUpdater.quitAndInstall());
+    notification.show();
+  });
+
+  autoUpdater.on("error", (err) => {
+    console.error("Update error:", err);
+  });
+
+  const check = () => {
+    autoUpdater.checkForUpdates().catch((err) => {
+      console.error("Update check failed:", err);
+    });
+  };
+  check();
+  setInterval(check, UPDATE_CHECK_INTERVAL_MS).unref();
+}
+
 function buildAppMenu(): Menu {
   const isMac = process.platform === "darwin";
   const settingsItem: MenuItemConstructorOptions = {
@@ -139,9 +171,7 @@ app.whenReady().then(async () => {
   await createWindow();
 
   if (app.isPackaged) {
-    autoUpdater.checkForUpdatesAndNotify().catch((err) => {
-      console.error("Update check failed:", err);
-    });
+    setupAutoUpdater();
   }
 });
 

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, app, dialog, ipcMain, shell } from "electron";
+import { BrowserWindow, Menu, app, ipcMain, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import { autoUpdater } from "electron-updater";
 import net from "node:net";
@@ -13,7 +13,6 @@ app.setName("GitHub Dashboard");
 
 let mainWindow: BrowserWindow | null = null;
 let serverPort = 0;
-let isQuitting = false;
 
 async function findFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -78,22 +77,6 @@ async function createWindow(): Promise<void> {
   });
 
   mainWindow.once("ready-to-show", () => mainWindow?.show());
-
-  // Closing the last window quits the app (see `window-all-closed`), so warn
-  // before letting that happen. Skipped when the close is part of an
-  // already-confirmed quit (menu Quit, Cmd+Q, etc.).
-  mainWindow.on("close", (e) => {
-    if (isQuitting || !mainWindow) return;
-    const choice = dialog.showMessageBoxSync(mainWindow, {
-      type: "question",
-      buttons: ["Quit", "Cancel"],
-      defaultId: 0,
-      cancelId: 1,
-      title: "Quit GitHub Dashboard?",
-      message: "Closing this window will quit GitHub Dashboard.",
-    });
-    if (choice === 1) e.preventDefault();
-  });
 
   mainWindow.on("closed", () => {
     mainWindow = null;
@@ -232,10 +215,6 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     setupAutoUpdater();
   }
-});
-
-app.on("before-quit", () => {
-  isQuitting = true;
 });
 
 app.on("window-all-closed", () => {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -85,21 +85,25 @@ async function createWindow(): Promise<void> {
 
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
-function setupAutoUpdater(): void {
-  // Notify once per downloaded version. If the user dismisses the OS
-  // notification we don't re-pop it on the next hourly check; a newer
-  // version (different `info.version`) will produce a fresh notification.
-  const notifiedVersions = new Set<string>();
+// Notify once per downloaded version. If the user dismisses the OS
+// notification we don't re-pop it on the next hourly check; a newer version
+// (different `version`) produces a fresh notification.
+const notifiedVersions = new Set<string>();
 
+function showUpdateNotification(version: string): void {
+  if (notifiedVersions.has(version)) return;
+  notifiedVersions.add(version);
+  const notification = new Notification({
+    title: "Update ready",
+    body: `Version ${version} is ready. Click to restart and install.`,
+  });
+  notification.on("click", () => autoUpdater.quitAndInstall());
+  notification.show();
+}
+
+function setupAutoUpdater(): void {
   autoUpdater.on("update-downloaded", (info) => {
-    if (notifiedVersions.has(info.version)) return;
-    notifiedVersions.add(info.version);
-    const notification = new Notification({
-      title: "Update ready",
-      body: `Version ${info.version} is ready. Click to restart and install.`,
-    });
-    notification.on("click", () => autoUpdater.quitAndInstall());
-    notification.show();
+    showUpdateNotification(info.version);
   });
 
   autoUpdater.on("error", (err) => {
@@ -113,6 +117,15 @@ function setupAutoUpdater(): void {
   };
   check();
   setInterval(check, UPDATE_CHECK_INTERVAL_MS).unref();
+}
+
+// Each toggle-on bumps the fake version so the dedup in
+// showUpdateNotification doesn't swallow successive simulations.
+let fakeUpdateCounter = 0;
+
+function simulateUpdate(): void {
+  fakeUpdateCounter++;
+  showUpdateNotification(`99.0.${fakeUpdateCounter}`);
 }
 
 function buildAppMenu(): Menu {
@@ -155,6 +168,23 @@ function buildAppMenu(): Menu {
     { role: "editMenu" },
     { role: "viewMenu" },
     { role: "windowMenu" },
+    ...(!app.isPackaged
+      ? ([
+          {
+            label: "Developer",
+            submenu: [
+              {
+                label: "Simulate update available",
+                type: "checkbox",
+                checked: false,
+                click: (menuItem) => {
+                  if (menuItem.checked) simulateUpdate();
+                },
+              },
+            ],
+          },
+        ] as MenuItemConstructorOptions[])
+      : []),
   ];
 
   return Menu.buildFromTemplate(template);

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -6,6 +6,11 @@ import path from "node:path";
 
 const DEV_WEB_URL = "http://localhost:7200";
 
+// In dev, `app.name` defaults to the package.json `name` ("@github-dashboard/
+// desktop"), which surfaces as "Electron" in the macOS app menu. Force it
+// here so the dev menu matches the packaged build (Info.plist sets it there).
+app.setName("GitHub Dashboard");
+
 let mainWindow: BrowserWindow | null = null;
 let serverPort = 0;
 

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, Notification, app, shell } from "electron";
+import { BrowserWindow, Menu, app, ipcMain, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import { autoUpdater } from "electron-updater";
 import net from "node:net";
@@ -85,25 +85,19 @@ async function createWindow(): Promise<void> {
 
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
-// Notify once per downloaded version. If the user dismisses the OS
-// notification we don't re-pop it on the next hourly check; a newer version
-// (different `version`) produces a fresh notification.
-const notifiedVersions = new Set<string>();
+// Whether an update has been downloaded and is waiting to install. Held here
+// so a renderer that mounts after `update-downloaded` fires can still query
+// via `ghd:has-pending-update`.
+let updatePending = false;
 
-function showUpdateNotification(version: string): void {
-  if (notifiedVersions.has(version)) return;
-  notifiedVersions.add(version);
-  const notification = new Notification({
-    title: "Update ready",
-    body: `Version ${version} is ready. Click to restart and install.`,
-  });
-  notification.on("click", () => autoUpdater.quitAndInstall());
-  notification.show();
+function announceUpdate(): void {
+  updatePending = true;
+  mainWindow?.webContents.send("ghd:update-available");
 }
 
 function setupAutoUpdater(): void {
-  autoUpdater.on("update-downloaded", (info) => {
-    showUpdateNotification(info.version);
+  autoUpdater.on("update-downloaded", () => {
+    announceUpdate();
   });
 
   autoUpdater.on("error", (err) => {
@@ -119,13 +113,8 @@ function setupAutoUpdater(): void {
   setInterval(check, UPDATE_CHECK_INTERVAL_MS).unref();
 }
 
-// Each toggle-on bumps the fake version so the dedup in
-// showUpdateNotification doesn't swallow successive simulations.
-let fakeUpdateCounter = 0;
-
 function simulateUpdate(): void {
-  fakeUpdateCounter++;
-  showUpdateNotification(`99.0.${fakeUpdateCounter}`);
+  announceUpdate();
 }
 
 function buildAppMenu(): Menu {
@@ -189,6 +178,18 @@ function buildAppMenu(): Menu {
 
   return Menu.buildFromTemplate(template);
 }
+
+ipcMain.handle("ghd:has-pending-update", () => updatePending);
+ipcMain.handle("ghd:install-update", () => {
+  // Dev/simulated path: no real download to install, so just relaunch so the
+  // header button still has a visible effect when exercising the flow.
+  if (!app.isPackaged) {
+    app.relaunch();
+    app.exit(0);
+    return;
+  }
+  autoUpdater.quitAndInstall();
+});
 
 app.whenReady().then(async () => {
   // In packaged builds the dock icon comes from Contents/Resources/icon.icns

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, app, ipcMain, shell } from "electron";
+import { BrowserWindow, Menu, app, dialog, ipcMain, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import { autoUpdater } from "electron-updater";
 import net from "node:net";
@@ -13,6 +13,7 @@ app.setName("GitHub Dashboard");
 
 let mainWindow: BrowserWindow | null = null;
 let serverPort = 0;
+let isQuitting = false;
 
 async function findFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -78,6 +79,26 @@ async function createWindow(): Promise<void> {
 
   mainWindow.once("ready-to-show", () => mainWindow?.show());
 
+  // Closing the last window quits the app (see `window-all-closed`), so warn
+  // before letting that happen. Skipped when the close is part of an
+  // already-confirmed quit (menu Quit, Cmd+Q, etc.).
+  mainWindow.on("close", (e) => {
+    if (isQuitting || !mainWindow) return;
+    const choice = dialog.showMessageBoxSync(mainWindow, {
+      type: "question",
+      buttons: ["Quit", "Cancel"],
+      defaultId: 0,
+      cancelId: 1,
+      title: "Quit GitHub Dashboard?",
+      message: "Closing this window will quit GitHub Dashboard.",
+    });
+    if (choice === 1) e.preventDefault();
+  });
+
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
+
   if (app.isPackaged) {
     await startEmbeddedServer();
     await mainWindow.loadURL(`http://localhost:${serverPort}/`);
@@ -97,7 +118,9 @@ let updatePending = false;
 
 function announceUpdate(): void {
   updatePending = true;
-  mainWindow?.webContents.send("ghd:update-available");
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("ghd:update-available");
+  }
 }
 
 function setupAutoUpdater(): void {
@@ -211,10 +234,10 @@ app.whenReady().then(async () => {
   }
 });
 
-app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") app.quit();
+app.on("before-quit", () => {
+  isQuitting = true;
 });
 
-app.on("activate", () => {
-  if (BrowserWindow.getAllWindows().length === 0) createWindow();
+app.on("window-all-closed", () => {
+  app.quit();
 });

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -6,4 +6,12 @@ contextBridge.exposeInMainWorld("electron", {
     ipcRenderer.on("ghd:open-settings", listener);
     return () => ipcRenderer.off("ghd:open-settings", listener);
   },
+  onUpdateAvailable: (cb: () => void): (() => void) => {
+    const listener = () => cb();
+    ipcRenderer.on("ghd:update-available", listener);
+    return () => ipcRenderer.off("ghd:update-available", listener);
+  },
+  hasPendingUpdate: (): Promise<boolean> =>
+    ipcRenderer.invoke("ghd:has-pending-update"),
+  installUpdate: (): Promise<void> => ipcRenderer.invoke("ghd:install-update"),
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { Settings } from "lucide-react";
+import { ArrowUpCircle, Settings } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AutoMergeNotAllowedError, api, type ConfigResponse } from "./api";
@@ -107,6 +107,7 @@ export function App() {
   const { data: instances, isLoading, error } = useInstances();
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [updateAvailable, setUpdateAvailable] = useState(false);
   const [theme] = useAtom(themeAtom);
   const headerRef = useRef<HTMLElement>(null);
 
@@ -129,6 +130,15 @@ export function App() {
 
   useEffect(() => {
     return window.electron?.onOpenSettings(() => setSettingsOpen(true));
+  }, []);
+
+  useEffect(() => {
+    const bridge = window.electron;
+    if (!bridge) return;
+    bridge.hasPendingUpdate().then((has) => {
+      if (has) setUpdateAvailable(true);
+    });
+    return bridge.onUpdateAvailable(() => setUpdateAvailable(true));
   }, []);
 
   useEffect(() => {
@@ -282,6 +292,18 @@ export function App() {
             })}
           </div>
           <div className="ml-auto flex items-center gap-1.5 [-webkit-app-region:no-drag]">
+            {updateAvailable && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => window.electron?.installUpdate()}
+                title="Restart and install update"
+                className="h-7 gap-1.5 border-emerald-500/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/20 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+              >
+                <ArrowUpCircle className="size-3.5" />
+                <Text bold>Update available</Text>
+              </Button>
+            )}
             <a
               href="https://github.com/AntonNiklasson/github-dashboard"
               target="_blank"

--- a/packages/web/src/types/electron.d.ts
+++ b/packages/web/src/types/electron.d.ts
@@ -1,5 +1,8 @@
 interface ElectronBridge {
   onOpenSettings(cb: () => void): () => void;
+  onUpdateAvailable(cb: () => void): () => void;
+  hasPendingUpdate(): Promise<boolean>;
+  installUpdate(): Promise<void>;
 }
 
 interface Window {


### PR DESCRIPTION
<img width="1000" alt="Screenshot 2026-05-18 at 14 34 56" src="https://github.com/user-attachments/assets/95445a1a-3a1c-457f-ad8f-144209ea8353" />


Reworks the auto-update flow into a few layered changes.

## 1. Hourly update poll
Replace the one-shot `checkForUpdatesAndNotify` (only ran at launch) with an hourly `setInterval` poll. `setInterval(...).unref()` so the timer doesn't keep the event loop alive after quit.

## 2. In-app notice in the header (replaces OS notification)
Main forwards `update-downloaded` to the renderer over IPC; the renderer shows an "Update available" pill in the header that calls `quitAndInstall` on click. A `hasPendingUpdate` invoke handler covers the race where the renderer mounts after the event fires. In dev/simulated mode `installUpdate` falls back to `app.relaunch(); app.exit(0)` so the button still has a visible effect.

The OS-level `Notification` path is gone — it was easy to miss and could not be re-shown once dismissed.

## 3. Dev-only Developer menu with simulate-update toggle
New "Developer" top-level menu shown only when `!app.isPackaged`. Single item is a checkbox "Simulate update available"; toggling it on fires the same announce path as a real `update-downloaded` event.

## 4. Misc
- `pnpm demo:desktop` script (mirrors `pnpm demo` for the electron flow).
- `app.setName("GitHub Dashboard")` so the dev menu reads the product name instead of "Electron". Packaged builds already got this from Info.plist.

## Test plan
- [ ] `pnpm demo:desktop`, open the Developer menu, toggle "Simulate update available" — header shows "Update available" pill. Click it → app relaunches.
- [ ] In a packaged build with at least one earlier release, observe the pill appear within an hour. Click → `quitAndInstall`.