### PR TITLE
Thread review-comment replies in PR detail panel

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -587,6 +587,7 @@ api.get("/:instanceId/prs/:owner/:repo/:prNumber/comments", async (c) => {
       body: c.body ?? "",
       createdAt: c.created_at,
       path: null as string | null,
+      inReplyToId: null as number | null,
     })),
     ...reviewComments.data.map((c) => ({
       id: c.id,
@@ -594,6 +595,7 @@ api.get("/:instanceId/prs/:owner/:repo/:prNumber/comments", async (c) => {
       body: c.body,
       createdAt: c.created_at,
       path: c.path,
+      inReplyToId: c.in_reply_to_id ?? null,
     })),
   ].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -187,6 +187,7 @@ export const api = {
         body: string;
         createdAt: string;
         path: string | null;
+        inReplyToId: number | null;
       }[]
     >(`/api/${instanceId}/prs/${owner}/${name}/${prNumber}/comments`);
   },

--- a/packages/web/src/components/PrPanel.tsx
+++ b/packages/web/src/components/PrPanel.tsx
@@ -404,13 +404,72 @@ function CommitsSection({
   );
 }
 
+type Comment = Awaited<ReturnType<typeof api.prComments>>[number];
+
+function buildThreads(
+  comments: Comment[],
+): { root: Comment; replies: Comment[] }[] {
+  const byId = new Map<number, Comment>();
+  for (const c of comments) byId.set(c.id, c);
+
+  // rootOf[id] = id of ultimate root (== id when itself a root).
+  // Path-compressed so each node resolves in O(1) amortized.
+  const rootOf = new Map<number, number>();
+  const resolveRoot = (start: Comment): number => {
+    const cached = rootOf.get(start.id);
+    if (cached != null) return cached;
+    const path: number[] = [];
+    let cur: Comment | undefined = start;
+    while (cur && cur.inReplyToId != null) {
+      const hit = rootOf.get(cur.id);
+      if (hit != null) {
+        for (const id of path) rootOf.set(id, hit);
+        return hit;
+      }
+      path.push(cur.id);
+      const parent = byId.get(cur.inReplyToId);
+      if (!parent || parent.id === cur.id) break;
+      cur = parent;
+    }
+    const rootId = cur?.id ?? start.id;
+    for (const id of path) rootOf.set(id, rootId);
+    rootOf.set(rootId, rootId);
+    return rootId;
+  };
+
+  const repliesByRoot = new Map<number, Comment[]>();
+  const roots: Comment[] = [];
+
+  // Input is already sorted asc by createdAt (server-side), so push order
+  // is chronological — no per-thread resort needed.
+  for (const c of comments) {
+    if (c.inReplyToId != null && byId.has(c.inReplyToId)) {
+      const rootId = resolveRoot(c);
+      if (rootId === c.id) {
+        roots.push(c);
+      } else {
+        const arr = repliesByRoot.get(rootId);
+        if (arr) arr.push(c);
+        else repliesByRoot.set(rootId, [c]);
+      }
+    } else {
+      roots.push(c);
+    }
+  }
+
+  return roots.map((root) => ({
+    root,
+    replies: repliesByRoot.get(root.id) ?? [],
+  }));
+}
+
 function CommentsTab({
   pr,
   comments,
   isLoading,
 }: {
   pr: PanelPr;
-  comments: Awaited<ReturnType<typeof api.prComments>> | undefined;
+  comments: Comment[] | undefined;
   isLoading: boolean;
 }) {
   if (isLoading) {
@@ -421,27 +480,53 @@ function CommentsTab({
     return <p className="text-sm text-muted-foreground">No comments</p>;
   }
 
+  const threads = buildThreads(comments);
+
   return (
     <div className="space-y-3">
-      {comments.map((c) => (
-        <div
-          key={c.id}
-          className="rounded-md border bg-card shadow-sm overflow-hidden"
-        >
-          <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">{c.author}</span>
-            <TimeAgo date={c.createdAt} />
-            {c.path && (
-              <span className="ml-auto truncate font-mono text-[11px]">
-                {c.path}
-              </span>
-            )}
-          </div>
-          <div className="px-3 py-2">
-            <MarkdownBody body={c.body} prUrl={pr.url} repo={pr.repo} />
-          </div>
+      {threads.map(({ root, replies }) => (
+        <div key={root.id} className="space-y-2">
+          <CommentCard comment={root} pr={pr} />
+          {replies.length > 0 && (
+            <div className="ml-4 space-y-2 border-l-2 border-muted pl-3">
+              <div className="text-[11px] text-muted-foreground">
+                {replies.length} {replies.length === 1 ? "reply" : "replies"}
+              </div>
+              {replies.map((r) => (
+                <CommentCard key={r.id} comment={r} pr={pr} isReply />
+              ))}
+            </div>
+          )}
         </div>
       ))}
+    </div>
+  );
+}
+
+function CommentCard({
+  comment,
+  pr,
+  isReply,
+}: {
+  comment: Comment;
+  pr: PanelPr;
+  isReply?: boolean;
+}) {
+  return (
+    <div className="rounded-md border bg-card shadow-sm overflow-hidden">
+      <div className="flex items-center gap-2 border-b bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">{comment.author}</span>
+        <TimeAgo date={comment.createdAt} />
+        {isReply && <span className="text-[11px] italic">replied</span>}
+        {comment.path && (
+          <span className="ml-auto truncate font-mono text-[11px]">
+            {comment.path}
+          </span>
+        )}
+      </div>
+      <div className="px-3 py-2">
+        <MarkdownBody body={comment.body} prUrl={pr.url} repo={pr.repo} />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/PrPanel.tsx
+++ b/packages/web/src/components/PrPanel.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, GitBranch, GitCommit } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
+import { type Comment, buildThreads } from "../pr-comment-threads";
 import { MarkdownBody } from "./MarkdownBody";
 import { ReviewStamp } from "./ReviewStamp";
 import { StatusBadge } from "./StatusBadge";
@@ -402,65 +403,6 @@ function CommitsSection({
       </div>
     </section>
   );
-}
-
-type Comment = Awaited<ReturnType<typeof api.prComments>>[number];
-
-function buildThreads(
-  comments: Comment[],
-): { root: Comment; replies: Comment[] }[] {
-  const byId = new Map<number, Comment>();
-  for (const c of comments) byId.set(c.id, c);
-
-  // rootOf[id] = id of ultimate root (== id when itself a root).
-  // Path-compressed so each node resolves in O(1) amortized.
-  const rootOf = new Map<number, number>();
-  const resolveRoot = (start: Comment): number => {
-    const cached = rootOf.get(start.id);
-    if (cached != null) return cached;
-    const path: number[] = [];
-    let cur: Comment | undefined = start;
-    while (cur && cur.inReplyToId != null) {
-      const hit = rootOf.get(cur.id);
-      if (hit != null) {
-        for (const id of path) rootOf.set(id, hit);
-        return hit;
-      }
-      path.push(cur.id);
-      const parent = byId.get(cur.inReplyToId);
-      if (!parent || parent.id === cur.id) break;
-      cur = parent;
-    }
-    const rootId = cur?.id ?? start.id;
-    for (const id of path) rootOf.set(id, rootId);
-    rootOf.set(rootId, rootId);
-    return rootId;
-  };
-
-  const repliesByRoot = new Map<number, Comment[]>();
-  const roots: Comment[] = [];
-
-  // Input is already sorted asc by createdAt (server-side), so push order
-  // is chronological — no per-thread resort needed.
-  for (const c of comments) {
-    if (c.inReplyToId != null && byId.has(c.inReplyToId)) {
-      const rootId = resolveRoot(c);
-      if (rootId === c.id) {
-        roots.push(c);
-      } else {
-        const arr = repliesByRoot.get(rootId);
-        if (arr) arr.push(c);
-        else repliesByRoot.set(rootId, [c]);
-      }
-    } else {
-      roots.push(c);
-    }
-  }
-
-  return roots.map((root) => ({
-    root,
-    replies: repliesByRoot.get(root.id) ?? [],
-  }));
 }
 
 function CommentsTab({

--- a/packages/web/src/pr-comment-threads.test.ts
+++ b/packages/web/src/pr-comment-threads.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { type Comment, buildThreads } from "./pr-comment-threads";
+
+// Helper so the tests focus on id/inReplyToId — everything else is filler.
+function c(id: number, inReplyToId: number | null = null): Comment {
+  return {
+    id,
+    author: "u",
+    body: "",
+    createdAt: new Date(2026, 0, 1, 0, 0, id).toISOString(),
+    path: null,
+    inReplyToId,
+  };
+}
+
+describe("buildThreads", () => {
+  it("returns [] for an empty list", () => {
+    expect(buildThreads([])).toEqual([]);
+  });
+
+  it("treats every comment as a root when there are no replies", () => {
+    const out = buildThreads([c(1), c(2), c(3)]);
+    expect(out.map((t) => t.root.id)).toEqual([1, 2, 3]);
+    expect(out.every((t) => t.replies.length === 0)).toBe(true);
+  });
+
+  it("groups replies under their root and preserves chronological order", () => {
+    // Server sorts asc by createdAt — replicate that order here.
+    const out = buildThreads([c(1), c(2, 1), c(3, 1)]);
+    expect(out).toHaveLength(1);
+    expect(out[0].root.id).toBe(1);
+    expect(out[0].replies.map((r) => r.id)).toEqual([2, 3]);
+  });
+
+  it("handles multiple independent threads", () => {
+    const out = buildThreads([c(1), c(2), c(3, 1), c(4, 2), c(5, 1)]);
+    expect(out.map((t) => t.root.id)).toEqual([1, 2]);
+    expect(out[0].replies.map((r) => r.id)).toEqual([3, 5]);
+    expect(out[1].replies.map((r) => r.id)).toEqual([4]);
+  });
+
+  it("promotes an orphan reply (parent not in dataset) to a root", () => {
+    // Reply points at id 99, which isn't in the input — fall through to root.
+    const out = buildThreads([c(1, 99), c(2, 1)]);
+    expect(out.map((t) => t.root.id)).toEqual([1]);
+    expect(out[0].replies.map((r) => r.id)).toEqual([2]);
+  });
+
+  it("walks nested chains up to the ultimate root", () => {
+    // C → B → A. GitHub's API normally flattens this, but the algorithm
+    // claims to handle deeper chains — verify it actually does.
+    const out = buildThreads([c(1), c(2, 1), c(3, 2)]);
+    expect(out).toHaveLength(1);
+    expect(out[0].root.id).toBe(1);
+    expect(out[0].replies.map((r) => r.id)).toEqual([2, 3]);
+  });
+
+  it("keeps issue-style comments (inReplyToId always null) as separate roots", () => {
+    const out = buildThreads([c(1), c(2), c(3)]);
+    expect(out).toHaveLength(3);
+  });
+
+  it("mixes issue comments and a review thread", () => {
+    const out = buildThreads([c(1), c(2), c(3, 2), c(4)]);
+    expect(out.map((t) => t.root.id)).toEqual([1, 2, 4]);
+    expect(out.find((t) => t.root.id === 2)?.replies.map((r) => r.id)).toEqual([
+      3,
+    ]);
+  });
+
+  it("breaks self-referential links instead of looping forever", () => {
+    // Pathological input: a comment that claims to reply to itself.
+    const out = buildThreads([c(1, 1)]);
+    expect(out.map((t) => t.root.id)).toEqual([1]);
+    expect(out[0].replies).toEqual([]);
+  });
+});

--- a/packages/web/src/pr-comment-threads.ts
+++ b/packages/web/src/pr-comment-threads.ts
@@ -1,0 +1,63 @@
+import type { api } from "./api";
+
+export type Comment = Awaited<ReturnType<typeof api.prComments>>[number];
+
+export interface Thread {
+  root: Comment;
+  replies: Comment[];
+}
+
+export function buildThreads(comments: Comment[]): Thread[] {
+  const byId = new Map<number, Comment>();
+  for (const c of comments) byId.set(c.id, c);
+
+  // rootOf[id] = id of ultimate root (== id when itself a root).
+  // Path-compressed so each node resolves in O(1) amortized.
+  const rootOf = new Map<number, number>();
+  const resolveRoot = (start: Comment): number => {
+    const cached = rootOf.get(start.id);
+    if (cached != null) return cached;
+    const path: number[] = [];
+    let cur: Comment | undefined = start;
+    while (cur && cur.inReplyToId != null) {
+      const hit = rootOf.get(cur.id);
+      if (hit != null) {
+        for (const id of path) rootOf.set(id, hit);
+        return hit;
+      }
+      path.push(cur.id);
+      const parent = byId.get(cur.inReplyToId);
+      if (!parent || parent.id === cur.id) break;
+      cur = parent;
+    }
+    const rootId = cur?.id ?? start.id;
+    for (const id of path) rootOf.set(id, rootId);
+    rootOf.set(rootId, rootId);
+    return rootId;
+  };
+
+  const repliesByRoot = new Map<number, Comment[]>();
+  const roots: Comment[] = [];
+
+  // Input is already sorted asc by createdAt (server-side), so push order
+  // is chronological — no per-thread resort needed.
+  for (const c of comments) {
+    if (c.inReplyToId != null && byId.has(c.inReplyToId)) {
+      const rootId = resolveRoot(c);
+      if (rootId === c.id) {
+        roots.push(c);
+      } else {
+        const arr = repliesByRoot.get(rootId);
+        if (arr) arr.push(c);
+        else repliesByRoot.set(rootId, [c]);
+      }
+    } else {
+      roots.push(c);
+    }
+  }
+
+  return roots.map((root) => ({
+    root,
+    replies: repliesByRoot.get(root.id) ?? [],
+  }));
+}


### PR DESCRIPTION
## Summary
- Group review comments by their `in_reply_to_id` chain so replies render indented under the root comment instead of as a flat chronological list
- Server returns `inReplyToId` on each comment (null for issue comments, which have no reply primitive in GitHub)
- Thread builder uses path compression so deep chains resolve in O(1) amortized per descendant; relies on server-side `createdAt` sort to skip a per-thread resort

## Test plan
- [ ] Open a PR with review-comment threads in the detail panel → replies appear nested under root with a left border and "N replies" label
- [ ] Issue comments still render as top-level cards
- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check`, `pnpm test` all green