### PR TITLE
Filter auto-routed review requests (CODEOWNERS-style)

### DIFF
--- a/.cache-demo/data.json
+++ b/.cache-demo/data.json
@@ -174,7 +174,7 @@
         "commits": 8,
         "commentCount": 3,
         "mergeable": true,
-        "requestedDirectly": true,
+        "autoAssigned": false,
         "instanceId": "github",
         "instanceLabel": "github.com"
       },
@@ -202,7 +202,7 @@
         "commits": 3,
         "commentCount": 1,
         "mergeable": true,
-        "requestedDirectly": false,
+        "autoAssigned": true,
         "instanceId": "github",
         "instanceLabel": "github.com"
       }

--- a/.cache-demo/data.json
+++ b/.cache-demo/data.json
@@ -174,6 +174,7 @@
         "commits": 8,
         "commentCount": 3,
         "mergeable": true,
+        "requestedDirectly": true,
         "instanceId": "github",
         "instanceLabel": "github.com"
       },
@@ -201,6 +202,7 @@
         "commits": 3,
         "commentCount": 1,
         "mergeable": true,
+        "requestedDirectly": false,
         "instanceId": "github",
         "instanceLabel": "github.com"
       }

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -4,6 +4,7 @@ const { mockOctokit, cacheStore } = vi.hoisted(() => ({
   mockOctokit: {
     search: { issuesAndPullRequests: vi.fn() },
     pulls: { get: vi.fn(), listReviews: vi.fn() },
+    issues: { listEventsForTimeline: vi.fn() },
     checks: { listForRef: vi.fn() },
     repos: { getCombinedStatusForRef: vi.fn(), get: vi.fn() },
     activity: { listNotificationsForAuthenticatedUser: vi.fn() },
@@ -44,6 +45,7 @@ beforeEach(() => {
   cacheStore.clear();
   // Safe defaults
   mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] });
+  mockOctokit.issues.listEventsForTimeline.mockResolvedValue({ data: [] });
   mockOctokit.repos.get.mockResolvedValue({
     data: { allow_auto_merge: false },
   });
@@ -280,75 +282,254 @@ describe("fetchNotifications", () => {
   });
 });
 
-describe("fetchReviews", () => {
-  function reviewSearchItem(over: Partial<Record<string, unknown>> = {}) {
-    return {
-      id: 1,
-      node_id: "PR_1",
-      number: 5,
-      title: "t",
-      html_url: "http://x",
-      repository_url: "https://api.github.com/repos/o/r",
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-02T00:00:00Z",
-      user: { login: "bob", avatar_url: "" },
-      draft: false,
-      ...over,
-    };
+describe("fetchReviews — autoAssigned", () => {
+  // getInstance mock at the top of the file returns username "alice".
+  const USERNAME = "alice";
+  const PR_AUTHOR = "bob";
+  const PR_CREATED_AT = "2026-01-01T00:00:00Z";
+
+  type Reviewer = { login: string };
+  type Team = { slug: string };
+  type TimelineEvent = {
+    event: string;
+    actor?: { login: string; type?: string };
+    requested_reviewer?: Reviewer | null;
+    requested_team?: Team | null;
+    created_at?: string;
+  };
+
+  function setup(opts: {
+    requestedReviewers?: Reviewer[];
+    requestedTeams?: Team[];
+    timeline?: TimelineEvent[];
+    timelineError?: Error;
+  }) {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 1,
+            node_id: "PR_1",
+            number: 5,
+            title: "t",
+            html_url: "http://x",
+            repository_url: "https://api.github.com/repos/o/r",
+            created_at: PR_CREATED_AT,
+            updated_at: "2026-01-02T00:00:00Z",
+            user: { login: PR_AUTHOR, avatar_url: "" },
+            draft: false,
+          },
+        ],
+      },
+    });
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        body: "",
+        head: { ref: "feat" },
+        base: { ref: "main" },
+        additions: 0,
+        deletions: 0,
+        commits: 0,
+        comments: 0,
+        review_comments: 0,
+        mergeable: true,
+        requested_reviewers: opts.requestedReviewers ?? [],
+        requested_teams: opts.requestedTeams ?? [],
+      },
+    });
+    if (opts.timelineError) {
+      mockOctokit.issues.listEventsForTimeline.mockRejectedValue(
+        opts.timelineError,
+      );
+    } else {
+      mockOctokit.issues.listEventsForTimeline.mockResolvedValue({
+        data: opts.timeline ?? [],
+      });
+    }
   }
 
-  it("marks requestedDirectly true when the user is in requested_reviewers", async () => {
-    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
-      data: { items: [reviewSearchItem()] },
-    });
-    mockOctokit.pulls.get.mockResolvedValue({
-      data: {
-        body: "",
-        head: { ref: "feat" },
-        base: { ref: "main" },
-        additions: 0,
-        deletions: 0,
-        commits: 0,
-        comments: 0,
-        review_comments: 0,
-        mergeable: true,
-        requested_reviewers: [{ login: "alice" }],
-        requested_teams: [],
-      },
-    });
+  async function getAutoAssigned() {
     const reviews = await fetchReviews("github");
-    expect(reviews[0].requestedDirectly).toBe(true);
+    return reviews[0].autoAssigned;
+  }
+
+  describe("direct path (user is in requested_reviewers)", () => {
+    const direct = (
+      actor: { login: string; type?: string },
+      created_at?: string,
+    ): TimelineEvent => ({
+      event: "review_requested",
+      actor,
+      requested_reviewer: { login: USERNAME },
+      created_at,
+    });
+
+    it("auto when PR author requests the user at PR creation", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [direct({ login: PR_AUTHOR }, PR_CREATED_AT)],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+    });
+
+    it("auto when PR author requests the user within 2s of creation (boundary)", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [direct({ login: PR_AUTHOR }, "2026-01-01T00:00:01.500Z")],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+    });
+
+    it("manual when PR author requests the user >2s after creation", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [direct({ login: PR_AUTHOR }, "2026-01-01T00:00:03Z")],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("manual when PR author manually requests the user much later", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [direct({ login: PR_AUTHOR }, "2026-01-01T00:10:00Z")],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("manual when a non-author human requests the user, even at PR creation", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [direct({ login: "dave" }, PR_CREATED_AT)],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("auto when a Bot-type actor requests the user (any timing)", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          direct(
+            { login: "some-app[bot]", type: "Bot" },
+            "2026-01-01T05:00:00Z",
+          ),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+    });
+
+    it("auto when actor login ends in [bot] even without a type field", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          direct({ login: "github-actions[bot]" }, "2026-01-01T05:00:00Z"),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+    });
+
+    it("manual when the only event targeting the user was added manually, even if other auto events exist for other reviewers", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          // Auto event, but for someone else
+          {
+            event: "review_requested",
+            actor: { login: PR_AUTHOR },
+            requested_reviewer: { login: "carol" },
+            created_at: PR_CREATED_AT,
+          },
+          // Manual event targeting the user
+          direct({ login: "dave" }, "2026-01-01T01:00:00Z"),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("manual when timeline has no review_requested events targeting the user", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
   });
 
-  it("marks requestedDirectly false when the user is only on a requested team", async () => {
-    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
-      data: { items: [reviewSearchItem()] },
+  describe("team path (user only via team membership)", () => {
+    const team = (
+      actor: { login: string; type?: string },
+      created_at?: string,
+    ): TimelineEvent => ({
+      event: "review_requested",
+      actor,
+      requested_team: { slug: "platform" },
+      created_at,
     });
-    mockOctokit.pulls.get.mockResolvedValue({
-      data: {
-        body: "",
-        head: { ref: "feat" },
-        base: { ref: "main" },
-        additions: 0,
-        deletions: 0,
-        commits: 0,
-        comments: 0,
-        review_comments: 0,
-        mergeable: true,
-        requested_reviewers: [{ login: "carol" }],
-        requested_teams: [{ slug: "platform" }],
-      },
+
+    const teamSetup = {
+      requestedReviewers: [{ login: "carol" }],
+      requestedTeams: [{ slug: "platform" }],
+    };
+
+    it("auto when PR author requests a team at PR creation", async () => {
+      setup({
+        ...teamSetup,
+        timeline: [team({ login: PR_AUTHOR }, PR_CREATED_AT)],
+      });
+      expect(await getAutoAssigned()).toBe(true);
     });
-    const reviews = await fetchReviews("github");
-    expect(reviews[0].requestedDirectly).toBe(false);
+
+    it("manual when PR author requests the team >2s after creation", async () => {
+      setup({
+        ...teamSetup,
+        timeline: [team({ login: PR_AUTHOR }, "2026-01-01T00:00:03Z")],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("manual when a non-author human requests the team", async () => {
+      setup({
+        ...teamSetup,
+        timeline: [team({ login: "dave" }, PR_CREATED_AT)],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("auto when a Bot actor requests the team", async () => {
+      setup({
+        ...teamSetup,
+        timeline: [
+          team(
+            { login: "github-actions[bot]", type: "Bot" },
+            "2026-01-01T05:00:00Z",
+          ),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+    });
   });
 
-  it("defaults requestedDirectly to false when pulls.get fails", async () => {
-    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
-      data: { items: [reviewSearchItem()] },
+  describe("fallbacks", () => {
+    it("false when timeline fetch fails", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timelineError: new Error("404"),
+      });
+      expect(await getAutoAssigned()).toBe(false);
     });
-    mockOctokit.pulls.get.mockRejectedValue(new Error("404"));
-    const reviews = await fetchReviews("github");
-    expect(reviews[0].requestedDirectly).toBe(false);
+
+    it("false when timeline events lack created_at and actor is the PR author", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          {
+            event: "review_requested",
+            actor: { login: PR_AUTHOR },
+            requested_reviewer: { login: USERNAME },
+            // no created_at
+          },
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
   });
 });

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -36,9 +36,8 @@ vi.mock("./cache.js", () => ({
   },
 }));
 
-const { fetchPrs, fetchNotifications, fetchRecentPrs } = await import(
-  "./fetchers.js"
-);
+const { fetchPrs, fetchNotifications, fetchRecentPrs, fetchReviews } =
+  await import("./fetchers.js");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -59,6 +58,8 @@ beforeEach(() => {
       comments: 0,
       review_comments: 0,
       mergeable: true,
+      requested_reviewers: [],
+      requested_teams: [],
     },
   });
   mockOctokit.checks.listForRef.mockResolvedValue({
@@ -276,5 +277,78 @@ describe("fetchNotifications", () => {
       unread: false,
       url: "http://x",
     });
+  });
+});
+
+describe("fetchReviews", () => {
+  function reviewSearchItem(over: Partial<Record<string, unknown>> = {}) {
+    return {
+      id: 1,
+      node_id: "PR_1",
+      number: 5,
+      title: "t",
+      html_url: "http://x",
+      repository_url: "https://api.github.com/repos/o/r",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      user: { login: "bob", avatar_url: "" },
+      draft: false,
+      ...over,
+    };
+  }
+
+  it("marks requestedDirectly true when the user is in requested_reviewers", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [reviewSearchItem()] },
+    });
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        body: "",
+        head: { ref: "feat" },
+        base: { ref: "main" },
+        additions: 0,
+        deletions: 0,
+        commits: 0,
+        comments: 0,
+        review_comments: 0,
+        mergeable: true,
+        requested_reviewers: [{ login: "alice" }],
+        requested_teams: [],
+      },
+    });
+    const reviews = await fetchReviews("github");
+    expect(reviews[0].requestedDirectly).toBe(true);
+  });
+
+  it("marks requestedDirectly false when the user is only on a requested team", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [reviewSearchItem()] },
+    });
+    mockOctokit.pulls.get.mockResolvedValue({
+      data: {
+        body: "",
+        head: { ref: "feat" },
+        base: { ref: "main" },
+        additions: 0,
+        deletions: 0,
+        commits: 0,
+        comments: 0,
+        review_comments: 0,
+        mergeable: true,
+        requested_reviewers: [{ login: "carol" }],
+        requested_teams: [{ slug: "platform" }],
+      },
+    });
+    const reviews = await fetchReviews("github");
+    expect(reviews[0].requestedDirectly).toBe(false);
+  });
+
+  it("defaults requestedDirectly to false when pulls.get fails", async () => {
+    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
+      data: { items: [reviewSearchItem()] },
+    });
+    mockOctokit.pulls.get.mockRejectedValue(new Error("404"));
+    const reviews = await fetchReviews("github");
+    expect(reviews[0].requestedDirectly).toBe(false);
   });
 });

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -532,4 +532,74 @@ describe("fetchReviews — autoAssigned", () => {
       expect(await getAutoAssigned()).toBe(false);
     });
   });
+
+  describe("caching", () => {
+    const cacheKey = "github:auto-assigned:o/r/5";
+
+    it("skips the timeline fetch when the PR's updated_at matches the cached entry", async () => {
+      cacheStore.set(cacheKey, {
+        value: true,
+        updatedAt: "2026-01-02T00:00:00Z", // matches reviewSearchItem default
+      });
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [], // would yield false if it were used
+      });
+      expect(await getAutoAssigned()).toBe(true);
+      expect(mockOctokit.issues.listEventsForTimeline).not.toHaveBeenCalled();
+    });
+
+    it("refetches the timeline when the PR's updated_at differs from the cached entry", async () => {
+      cacheStore.set(cacheKey, {
+        value: true,
+        updatedAt: "2025-12-31T00:00:00Z", // stale
+      });
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          {
+            event: "review_requested",
+            actor: { login: "dave" }, // non-author manual request
+            requested_reviewer: { login: USERNAME },
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+      expect(mockOctokit.issues.listEventsForTimeline).toHaveBeenCalledTimes(1);
+      // Cache should now reflect the fresh value and the new updated_at.
+      expect(cacheStore.get(cacheKey)).toEqual({
+        value: false,
+        updatedAt: "2026-01-02T00:00:00Z",
+      });
+    });
+
+    it("does not write to cache when the timeline fetch fails", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timelineError: new Error("404"),
+      });
+      expect(await getAutoAssigned()).toBe(false);
+      expect(cacheStore.has(cacheKey)).toBe(false);
+    });
+
+    it("populates the cache on a cache miss with a successful timeline fetch", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          {
+            event: "review_requested",
+            actor: { login: PR_AUTHOR },
+            requested_reviewer: { login: USERNAME },
+            created_at: PR_CREATED_AT,
+          },
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+      expect(cacheStore.get(cacheKey)).toEqual({
+        value: true,
+        updatedAt: "2026-01-02T00:00:00Z",
+      });
+    });
+  });
 });

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -323,7 +323,7 @@ export async function fetchReviews(instanceId: string) {
       const [owner, repo] = item.repository_url.split("/").slice(-2);
       const prNumber = item.number;
 
-      const [ciStatus, reviewsRes, prRes] = await Promise.all([
+      const [ciStatus, reviewsRes, prRes, timelineRes] = await Promise.all([
         getCiStatus(client, owner, repo, `pull/${prNumber}/head`),
         client.pulls
           .listReviews({ owner, repo, pull_number: prNumber })
@@ -331,14 +331,61 @@ export async function fetchReviews(instanceId: string) {
         client.pulls
           .get({ owner, repo, pull_number: prNumber })
           .catch(() => null),
+        client.issues
+          .listEventsForTimeline({
+            owner,
+            repo,
+            issue_number: prNumber,
+            per_page: 100,
+          })
+          .catch(() => null),
       ]);
 
       const reviews = reviewsRes?.data ?? [];
       const prData = prRes?.data;
       const mqStatus = mergeQueueStatus.get(item.node_id);
-      const requestedDirectly =
+
+      // A review request counts as automatic when either:
+      //   - the actor is a bot (login ends in `[bot]` or type is "Bot"), or
+      //   - the actor is the PR author AND the event fired at the same time
+      //     as the PR was opened (within 2s).
+      // Manual requests by the PR author (later clicks of "Request review")
+      // share the actor but not the timing, so they correctly stay visible.
+      const prAuthor = item.user?.login;
+      const prCreatedMs = item.created_at ? Date.parse(item.created_at) : null;
+      const inRequestedReviewers =
         prData?.requested_reviewers?.some((r) => r?.login === username) ??
         false;
+      const timelineEvents = (timelineRes?.data ?? []) as Array<{
+        event?: string;
+        created_at?: string;
+        actor?: { login?: string; type?: string } | null;
+        requested_reviewer?: { login?: string } | null;
+        requested_team?: { slug?: string } | null;
+      }>;
+      const isAutoActor = (
+        actor: { login?: string; type?: string } | null | undefined,
+        eventCreatedAt?: string,
+      ) => {
+        if (!actor?.login) return false;
+        if (actor.type === "Bot" || actor.login.endsWith("[bot]")) return true;
+        if (!prAuthor || actor.login !== prAuthor) return false;
+        if (prCreatedMs == null || !eventCreatedAt) return false;
+        return Math.abs(Date.parse(eventCreatedAt) - prCreatedMs) <= 2000;
+      };
+      const autoAssigned = inRequestedReviewers
+        ? timelineEvents.some(
+            (ev) =>
+              ev.event === "review_requested" &&
+              ev.requested_reviewer?.login === username &&
+              isAutoActor(ev.actor, ev.created_at),
+          )
+        : timelineEvents.some(
+            (ev) =>
+              ev.event === "review_requested" &&
+              ev.requested_team != null &&
+              isAutoActor(ev.actor, ev.created_at),
+          );
 
       return {
         id: item.id,
@@ -367,9 +414,9 @@ export async function fetchReviews(instanceId: string) {
         commits: prData?.commits ?? 0,
         commentCount: (prData?.comments ?? 0) + (prData?.review_comments ?? 0),
         mergeable: prData?.mergeable ?? null,
-        // False when the request came in via team membership (e.g.
-        // CODEOWNERS auto-assignment) rather than a direct user request.
-        requestedDirectly,
+        // True when CODEOWNERS auto-attached this user (directly or via a
+        // team). Manual user/team requests stay false.
+        autoAssigned,
       };
     }),
   );

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -323,6 +323,15 @@ export async function fetchReviews(instanceId: string) {
       const [owner, repo] = item.repository_url.split("/").slice(-2);
       const prNumber = item.number;
 
+      // autoAssigned only changes when the PR changes (push, comment, review,
+      // CODEOWNERS re-eval all bump updated_at). Cache by (instance, repo,
+      // number) and re-fetch the timeline only when updated_at moves.
+      const autoCacheKey = `${instanceId}:auto-assigned:${owner}/${repo}/${prNumber}`;
+      const cachedAuto = getCached<{ value: boolean; updatedAt: string }>(
+        autoCacheKey,
+      );
+      const useCachedAuto = cachedAuto?.updatedAt === item.updated_at;
+
       const [ciStatus, reviewsRes, prRes, timelineRes] = await Promise.all([
         getCiStatus(client, owner, repo, `pull/${prNumber}/head`),
         client.pulls
@@ -331,14 +340,16 @@ export async function fetchReviews(instanceId: string) {
         client.pulls
           .get({ owner, repo, pull_number: prNumber })
           .catch(() => null),
-        client.issues
-          .listEventsForTimeline({
-            owner,
-            repo,
-            issue_number: prNumber,
-            per_page: 100,
-          })
-          .catch(() => null),
+        useCachedAuto
+          ? Promise.resolve(null)
+          : client.issues
+              .listEventsForTimeline({
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100,
+              })
+              .catch(() => null),
       ]);
 
       const reviews = reviewsRes?.data ?? [];
@@ -351,41 +362,58 @@ export async function fetchReviews(instanceId: string) {
       //     as the PR was opened (within 2s).
       // Manual requests by the PR author (later clicks of "Request review")
       // share the actor but not the timing, so they correctly stay visible.
-      const prAuthor = item.user?.login;
-      const prCreatedMs = item.created_at ? Date.parse(item.created_at) : null;
-      const inRequestedReviewers =
-        prData?.requested_reviewers?.some((r) => r?.login === username) ??
-        false;
-      const timelineEvents = (timelineRes?.data ?? []) as Array<{
-        event?: string;
-        created_at?: string;
-        actor?: { login?: string; type?: string } | null;
-        requested_reviewer?: { login?: string } | null;
-        requested_team?: { slug?: string } | null;
-      }>;
-      const isAutoActor = (
-        actor: { login?: string; type?: string } | null | undefined,
-        eventCreatedAt?: string,
-      ) => {
-        if (!actor?.login) return false;
-        if (actor.type === "Bot" || actor.login.endsWith("[bot]")) return true;
-        if (!prAuthor || actor.login !== prAuthor) return false;
-        if (prCreatedMs == null || !eventCreatedAt) return false;
-        return Math.abs(Date.parse(eventCreatedAt) - prCreatedMs) <= 2000;
-      };
-      const autoAssigned = inRequestedReviewers
-        ? timelineEvents.some(
-            (ev) =>
-              ev.event === "review_requested" &&
-              ev.requested_reviewer?.login === username &&
-              isAutoActor(ev.actor, ev.created_at),
-          )
-        : timelineEvents.some(
-            (ev) =>
-              ev.event === "review_requested" &&
-              ev.requested_team != null &&
-              isAutoActor(ev.actor, ev.created_at),
-          );
+      let autoAssigned: boolean;
+      if (useCachedAuto && cachedAuto) {
+        autoAssigned = cachedAuto.value;
+      } else {
+        const prAuthor = item.user?.login;
+        const prCreatedMs = item.created_at
+          ? Date.parse(item.created_at)
+          : null;
+        const inRequestedReviewers =
+          prData?.requested_reviewers?.some((r) => r?.login === username) ??
+          false;
+        const timelineEvents = (timelineRes?.data ?? []) as Array<{
+          event?: string;
+          created_at?: string;
+          actor?: { login?: string; type?: string } | null;
+          requested_reviewer?: { login?: string } | null;
+          requested_team?: { slug?: string } | null;
+        }>;
+        const isAutoActor = (
+          actor: { login?: string; type?: string } | null | undefined,
+          eventCreatedAt?: string,
+        ) => {
+          if (!actor?.login) return false;
+          if (actor.type === "Bot" || actor.login.endsWith("[bot]"))
+            return true;
+          if (!prAuthor || actor.login !== prAuthor) return false;
+          if (prCreatedMs == null || !eventCreatedAt) return false;
+          return Math.abs(Date.parse(eventCreatedAt) - prCreatedMs) <= 2000;
+        };
+        autoAssigned = inRequestedReviewers
+          ? timelineEvents.some(
+              (ev) =>
+                ev.event === "review_requested" &&
+                ev.requested_reviewer?.login === username &&
+                isAutoActor(ev.actor, ev.created_at),
+            )
+          : timelineEvents.some(
+              (ev) =>
+                ev.event === "review_requested" &&
+                ev.requested_team != null &&
+                isAutoActor(ev.actor, ev.created_at),
+            );
+        // Only persist when the timeline fetch actually succeeded — a 404 /
+        // throttle shouldn't burn a "false" into the cache and shadow a real
+        // auto-assignment.
+        if (timelineRes != null) {
+          setCached(autoCacheKey, {
+            value: autoAssigned,
+            updatedAt: item.updated_at,
+          });
+        }
+      }
 
       return {
         id: item.id,

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -336,6 +336,9 @@ export async function fetchReviews(instanceId: string) {
       const reviews = reviewsRes?.data ?? [];
       const prData = prRes?.data;
       const mqStatus = mergeQueueStatus.get(item.node_id);
+      const requestedDirectly =
+        prData?.requested_reviewers?.some((r) => r?.login === username) ??
+        false;
 
       return {
         id: item.id,
@@ -364,6 +367,9 @@ export async function fetchReviews(instanceId: string) {
         commits: prData?.commits ?? 0,
         commentCount: (prData?.comments ?? 0) + (prData?.review_comments ?? 0),
         mergeable: prData?.mergeable ?? null,
+        // False when the request came in via team membership (e.g.
+        // CODEOWNERS auto-assignment) rather than a direct user request.
+        requestedDirectly,
       };
     }),
   );

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,7 +13,7 @@ import {
   mergeActionLabel,
 } from "./merge-decision";
 import { dismissKey, dismissedReviewsAtom, isDismissed } from "./dismissed";
-import { showTeamReviewRequestsAtom } from "./filters";
+import { showCodeOwnerRequestsAtom } from "./filters";
 import { useChords } from "./use-chords";
 import {
   type Action,
@@ -678,8 +678,8 @@ function Dashboard({ source }: { source: DashboardSource }) {
   const queryClient = useQueryClient();
   const { instances, prs, recentPrs, reviews, notifications } = source;
   const [dismissed, setDismissed] = useAtom(dismissedReviewsAtom);
-  const [showTeamReviewRequests, setShowTeamReviewRequests] = useAtom(
-    showTeamReviewRequestsAtom,
+  const [showCodeOwnerRequests, setShowCodeOwnerRequests] = useAtom(
+    showCodeOwnerRequestsAtom,
   );
   const [prSort, setPrSort] = useAtom(prSortAtom);
   const [reviewSort, setReviewSort] = useAtom(reviewSortAtom);
@@ -694,9 +694,9 @@ function Dashboard({ source }: { source: DashboardSource }) {
     () =>
       reviews.data
         .filter((r) => !isDismissed(dismissed, r.repo, r.number, r.updatedAt))
-        .filter((r) => showTeamReviewRequests || r.requestedDirectly !== false)
+        .filter((r) => showCodeOwnerRequests || r.autoAssigned !== true)
         .sort((a, b) => compareReviews(a, b, reviewSort)),
-    [reviews.data, dismissed, showTeamReviewRequests, reviewSort],
+    [reviews.data, dismissed, showCodeOwnerRequests, reviewSort],
   );
 
   const sortedNotifications = useMemo(
@@ -989,7 +989,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
         }
       } else if (e.key === "f" && activeSection === "reviews") {
         e.preventDefault();
-        setShowTeamReviewRequests((v) => !v);
+        setShowCodeOwnerRequests((v) => !v);
       } else if (e.key === "e" && activeSection === "reviews") {
         const r = reviewsRef.current[focusIndex];
         if (r) {
@@ -1124,24 +1124,24 @@ function Dashboard({ source }: { source: DashboardSource }) {
           <div className="flex gap-x-4">
             <label
               className="flex cursor-pointer items-center gap-1.5 select-none"
-              title="Includes CODEOWNERS auto-assignments and manual team requests — GitHub's API doesn't distinguish them."
+              title="Show reviews that CODEOWNERS auto-attached to you (directly or via a team). Manual user and team requests are always shown."
               onClick={(e) => e.stopPropagation()}
             >
               <input
                 type="checkbox"
-                checked={showTeamReviewRequests}
-                onChange={(e) => setShowTeamReviewRequests(e.target.checked)}
+                checked={showCodeOwnerRequests}
+                onChange={(e) => setShowCodeOwnerRequests(e.target.checked)}
                 className="h-3 w-3 rounded"
               />
               <span
                 className={
                   "text-[10px] uppercase tracking-tight " +
-                  (showTeamReviewRequests
+                  (showCodeOwnerRequests
                     ? "text-foreground"
                     : "text-muted-foreground/70")
                 }
               >
-                Auto requests
+                Code owners
               </span>
             </label>
             <SortControl

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,6 +13,7 @@ import {
   mergeActionLabel,
 } from "./merge-decision";
 import { dismissKey, dismissedReviewsAtom, isDismissed } from "./dismissed";
+import { hideTeamReviewRequestsAtom } from "./filters";
 import { useChords } from "./use-chords";
 import {
   type Action,
@@ -677,6 +678,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
   const queryClient = useQueryClient();
   const { instances, prs, recentPrs, reviews, notifications } = source;
   const [dismissed, setDismissed] = useAtom(dismissedReviewsAtom);
+  const [hideTeamReviewRequests] = useAtom(hideTeamReviewRequestsAtom);
   const [prSort, setPrSort] = useAtom(prSortAtom);
   const [reviewSort, setReviewSort] = useAtom(reviewSortAtom);
   const [notificationSort, setNotificationSort] = useAtom(notificationSortAtom);
@@ -690,8 +692,9 @@ function Dashboard({ source }: { source: DashboardSource }) {
     () =>
       reviews.data
         .filter((r) => !isDismissed(dismissed, r.repo, r.number, r.updatedAt))
+        .filter((r) => !hideTeamReviewRequests || r.requestedDirectly !== false)
         .sort((a, b) => compareReviews(a, b, reviewSort)),
-    [reviews.data, dismissed, reviewSort],
+    [reviews.data, dismissed, hideTeamReviewRequests, reviewSort],
   );
 
   const sortedNotifications = useMemo(

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1121,7 +1121,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
           nav.setFocusIndex(0);
         }}
         right={
-          <>
+          <div className="flex gap-x-4">
             <label
               className="flex cursor-pointer items-center gap-1.5 select-none"
               title="Includes CODEOWNERS auto-assignments and manual team requests — GitHub's API doesn't distinguish them."
@@ -1141,7 +1141,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
                     : "text-muted-foreground/70")
                 }
               >
-                Show auto requests
+                Auto requests
               </span>
             </label>
             <SortControl
@@ -1149,7 +1149,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
               value={reviewSort}
               onChange={setReviewSort}
             />
-          </>
+          </div>
         }
       >
         {reviews.isLoading ? (

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -13,7 +13,7 @@ import {
   mergeActionLabel,
 } from "./merge-decision";
 import { dismissKey, dismissedReviewsAtom, isDismissed } from "./dismissed";
-import { hideTeamReviewRequestsAtom } from "./filters";
+import { showTeamReviewRequestsAtom } from "./filters";
 import { useChords } from "./use-chords";
 import {
   type Action,
@@ -678,7 +678,9 @@ function Dashboard({ source }: { source: DashboardSource }) {
   const queryClient = useQueryClient();
   const { instances, prs, recentPrs, reviews, notifications } = source;
   const [dismissed, setDismissed] = useAtom(dismissedReviewsAtom);
-  const [hideTeamReviewRequests] = useAtom(hideTeamReviewRequestsAtom);
+  const [showTeamReviewRequests, setShowTeamReviewRequests] = useAtom(
+    showTeamReviewRequestsAtom,
+  );
   const [prSort, setPrSort] = useAtom(prSortAtom);
   const [reviewSort, setReviewSort] = useAtom(reviewSortAtom);
   const [notificationSort, setNotificationSort] = useAtom(notificationSortAtom);
@@ -692,9 +694,9 @@ function Dashboard({ source }: { source: DashboardSource }) {
     () =>
       reviews.data
         .filter((r) => !isDismissed(dismissed, r.repo, r.number, r.updatedAt))
-        .filter((r) => !hideTeamReviewRequests || r.requestedDirectly !== false)
+        .filter((r) => showTeamReviewRequests || r.requestedDirectly !== false)
         .sort((a, b) => compareReviews(a, b, reviewSort)),
-    [reviews.data, dismissed, hideTeamReviewRequests, reviewSort],
+    [reviews.data, dismissed, showTeamReviewRequests, reviewSort],
   );
 
   const sortedNotifications = useMemo(
@@ -985,6 +987,9 @@ function Dashboard({ source }: { source: DashboardSource }) {
             .catch(() => {})
             .finally(() => setTogglingDraftId(null));
         }
+      } else if (e.key === "f" && activeSection === "reviews") {
+        e.preventDefault();
+        setShowTeamReviewRequests((v) => !v);
       } else if (e.key === "e" && activeSection === "reviews") {
         const r = reviewsRef.current[focusIndex];
         if (r) {
@@ -1059,8 +1064,8 @@ function Dashboard({ source }: { source: DashboardSource }) {
     <div className="grid h-full grid-cols-[2fr_2fr_1fr] overflow-hidden">
       <Column
         section="prs"
-        label="My PRs"
-        count={itemCounts.prs}
+        label="My work"
+        count={sortedPrs.length}
         isActive={nav.activeSection === "prs"}
         isFetching={prs.isFetching}
         onActivate={() => {
@@ -1107,7 +1112,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
 
       <Column
         section="reviews"
-        label="Review Requests"
+        label="Reviews"
         count={itemCounts.reviews}
         isActive={nav.activeSection === "reviews"}
         isFetching={reviews.isFetching}
@@ -1116,11 +1121,35 @@ function Dashboard({ source }: { source: DashboardSource }) {
           nav.setFocusIndex(0);
         }}
         right={
-          <SortControl
-            fields={REVIEW_SORT_FIELDS}
-            value={reviewSort}
-            onChange={setReviewSort}
-          />
+          <>
+            <label
+              className="flex cursor-pointer items-center gap-1.5 select-none"
+              title="Includes CODEOWNERS auto-assignments and manual team requests — GitHub's API doesn't distinguish them."
+              onClick={(e) => e.stopPropagation()}
+            >
+              <input
+                type="checkbox"
+                checked={showTeamReviewRequests}
+                onChange={(e) => setShowTeamReviewRequests(e.target.checked)}
+                className="h-3 w-3 rounded"
+              />
+              <span
+                className={
+                  "text-[10px] uppercase tracking-tight " +
+                  (showTeamReviewRequests
+                    ? "text-foreground"
+                    : "text-muted-foreground/70")
+                }
+              >
+                Show auto requests
+              </span>
+            </label>
+            <SortControl
+              fields={REVIEW_SORT_FIELDS}
+              value={reviewSort}
+              onChange={setReviewSort}
+            />
+          </>
         }
       >
         {reviews.isLoading ? (

--- a/packages/web/src/components/SettingsModal.tsx
+++ b/packages/web/src/components/SettingsModal.tsx
@@ -3,7 +3,6 @@ import { useAtom } from "jotai";
 import { toast } from "sonner";
 import { Settings, Globe, Building2 } from "lucide-react";
 import { api, type ConfigData, ConfigValidationError } from "../api";
-import { hideTeamReviewRequestsAtom } from "../filters";
 import { type Theme, applyTheme, themeAtom } from "../theme";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -57,9 +56,6 @@ function GeneralTab({
   setPort: (v: string) => void;
 }) {
   const [theme, setTheme] = useAtom(themeAtom);
-  const [hideTeamReviewRequests, setHideTeamReviewRequests] = useAtom(
-    hideTeamReviewRequestsAtom,
-  );
 
   useEffect(() => applyTheme(theme), [theme]);
 
@@ -82,28 +78,6 @@ function GeneralTab({
             <option value="dark">Dark</option>
           </select>
         </div>
-      </div>
-      <div className="space-y-3">
-        <h3>
-          <Text bold>Review requests</Text>
-        </h3>
-        <label className="flex items-start gap-2 text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={hideTeamReviewRequests}
-            onChange={(e) => setHideTeamReviewRequests(e.target.checked)}
-            className="mt-1 rounded"
-          />
-          <span className="space-y-0.5">
-            <Text>Hide requests routed via a team</Text>
-            <span className="block">
-              <Text size="small" variant="tertiary">
-                Filters out CODEOWNERS auto-assignments. Also hides manual team
-                requests — GitHub's API doesn't distinguish them.
-              </Text>
-            </span>
-          </span>
-        </label>
       </div>
       <div className="space-y-3">
         <h3>

--- a/packages/web/src/components/SettingsModal.tsx
+++ b/packages/web/src/components/SettingsModal.tsx
@@ -3,6 +3,7 @@ import { useAtom } from "jotai";
 import { toast } from "sonner";
 import { Settings, Globe, Building2 } from "lucide-react";
 import { api, type ConfigData, ConfigValidationError } from "../api";
+import { hideTeamReviewRequestsAtom } from "../filters";
 import { type Theme, applyTheme, themeAtom } from "../theme";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,6 +57,10 @@ function GeneralTab({
   setPort: (v: string) => void;
 }) {
   const [theme, setTheme] = useAtom(themeAtom);
+  const [hideTeamReviewRequests, setHideTeamReviewRequests] = useAtom(
+    hideTeamReviewRequestsAtom,
+  );
+
   useEffect(() => applyTheme(theme), [theme]);
 
   return (
@@ -77,6 +82,28 @@ function GeneralTab({
             <option value="dark">Dark</option>
           </select>
         </div>
+      </div>
+      <div className="space-y-3">
+        <h3>
+          <Text bold>Review requests</Text>
+        </h3>
+        <label className="flex items-start gap-2 text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={hideTeamReviewRequests}
+            onChange={(e) => setHideTeamReviewRequests(e.target.checked)}
+            className="mt-1 rounded"
+          />
+          <span className="space-y-0.5">
+            <Text>Hide requests routed via a team</Text>
+            <span className="block">
+              <Text size="small" variant="tertiary">
+                Filters out CODEOWNERS auto-assignments. Also hides manual team
+                requests — GitHub's API doesn't distinguish them.
+              </Text>
+            </span>
+          </span>
+        </label>
       </div>
       <div className="space-y-3">
         <h3>

--- a/packages/web/src/components/ShortcutHelp.tsx
+++ b/packages/web/src/components/ShortcutHelp.tsx
@@ -36,7 +36,7 @@ const sections: { title: string; shortcuts: [string, string][] }[] = [
       ["a", "Approve PR"],
       ["c", "Close PR"],
       ["e", "Dismiss review / notification"],
-      ["f", "Toggle auto-routed reviews"],
+      ["f", "Toggle CODEOWNERS-attached reviews"],
       ["s", "Cycle sort dimension"],
       ["S", "Toggle sort direction"],
     ],

--- a/packages/web/src/components/ShortcutHelp.tsx
+++ b/packages/web/src/components/ShortcutHelp.tsx
@@ -36,6 +36,7 @@ const sections: { title: string; shortcuts: [string, string][] }[] = [
       ["a", "Approve PR"],
       ["c", "Close PR"],
       ["e", "Dismiss review / notification"],
+      ["f", "Toggle auto-routed reviews"],
       ["s", "Cycle sort dimension"],
       ["S", "Toggle sort direction"],
     ],

--- a/packages/web/src/components/SortControl.tsx
+++ b/packages/web/src/components/SortControl.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils";
 import type { SortFieldOption, SortState } from "../sort";
 
 interface Props<F extends string> {
@@ -12,39 +11,26 @@ export function SortControl<F extends string>({
   value,
   onChange,
 }: Props<F>) {
+  const activeIdx = fields.findIndex((f) => f.field === value.field);
+  const active = fields[activeIdx] ?? fields[0];
+
   return (
     <div className="flex items-center gap-2">
-      {fields.map((opt) => {
-        const active = opt.field === value.field;
-        return (
-          <button
-            key={opt.field}
-            type="button"
-            className={cn(
-              "text-[10px] uppercase tracking-tight tabular-nums",
-              active
-                ? "text-foreground"
-                : "text-muted-foreground/70 hover:text-foreground",
-            )}
-            onClick={(e) => {
-              e.stopPropagation();
-              if (active) {
-                onChange({
-                  field: opt.field,
-                  dir: value.dir === "asc" ? "desc" : "asc",
-                });
-              } else {
-                onChange({ field: opt.field, dir: "desc" });
-              }
-            }}
-          >
-            {opt.label}
-            {active && (
-              <span className="ml-0.5">{value.dir === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
-        );
-      })}
+      <button
+        type="button"
+        className="text-[10px] uppercase tracking-tight tabular-nums text-foreground"
+        title="Click to flip direction · press s to cycle dimensions"
+        onClick={(e) => {
+          e.stopPropagation();
+          onChange({
+            field: active.field,
+            dir: value.dir === "asc" ? "desc" : "asc",
+          });
+        }}
+      >
+        {active.label}
+        <span className="ml-0.5">{value.dir === "asc" ? "↑" : "↓"}</span>
+      </button>
     </div>
   );
 }

--- a/packages/web/src/filters.ts
+++ b/packages/web/src/filters.ts
@@ -1,0 +1,10 @@
+import { atomWithStorage } from "jotai/utils";
+
+// Hide review requests where the user was attached via team membership rather
+// than asked directly. Captures most CODEOWNERS auto-assignments — at the cost
+// of also hiding manual team requests, which the GitHub API doesn't let us
+// distinguish.
+export const hideTeamReviewRequestsAtom = atomWithStorage<boolean>(
+  "hideTeamReviewRequests",
+  false,
+);

--- a/packages/web/src/filters.ts
+++ b/packages/web/src/filters.ts
@@ -1,10 +1,9 @@
 import { atomWithStorage } from "jotai/utils";
 
-// Show review requests where the user was attached via team membership rather
-// than asked directly. Off catches most CODEOWNERS auto-assignments — at the
-// cost of also hiding manual team requests, which the GitHub API doesn't let
-// us distinguish.
-export const showTeamReviewRequestsAtom = atomWithStorage<boolean>(
-  "showTeamReviewRequests",
+// When false, hide reviews where CODEOWNERS auto-attached the current user
+// (directly or via a team). Manual user/team requests stay visible either
+// way. Defaults to true.
+export const showCodeOwnerRequestsAtom = atomWithStorage<boolean>(
+  "showCodeOwnerRequests",
   true,
 );

--- a/packages/web/src/filters.ts
+++ b/packages/web/src/filters.ts
@@ -1,10 +1,10 @@
 import { atomWithStorage } from "jotai/utils";
 
-// Hide review requests where the user was attached via team membership rather
-// than asked directly. Captures most CODEOWNERS auto-assignments — at the cost
-// of also hiding manual team requests, which the GitHub API doesn't let us
-// distinguish.
-export const hideTeamReviewRequestsAtom = atomWithStorage<boolean>(
-  "hideTeamReviewRequests",
-  false,
+// Show review requests where the user was attached via team membership rather
+// than asked directly. Off catches most CODEOWNERS auto-assignments — at the
+// cost of also hiding manual team requests, which the GitHub API doesn't let
+// us distinguish.
+export const showTeamReviewRequestsAtom = atomWithStorage<boolean>(
+  "showTeamReviewRequests",
+  true,
 );

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -65,7 +65,7 @@ export interface ReviewRequest {
   instanceId?: string;
   instanceLabel?: string;
   mergeable?: boolean | null;
-  requestedDirectly?: boolean;
+  autoAssigned?: boolean;
 }
 
 export interface Notification {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -65,6 +65,7 @@ export interface ReviewRequest {
   instanceId?: string;
   instanceLabel?: string;
   mergeable?: boolean | null;
+  requestedDirectly?: boolean;
 }
 
 export interface Notification {


### PR DESCRIPTION
## Summary
Hide CODEOWNERS auto-attached review requests when the "Code owners" toggle in the Reviews column is off. Manual user and manual team requests stay visible.

## Detection
A `review_requested` event counts as automatic when either:
- the **actor is a bot** (`type === "Bot"` or login ends in `[bot]`), or
- the **actor is the PR author AND the event fires within 2s of PR creation**.

This was reached empirically. Real timelines in `sana-labs/sana-ai` show two patterns:

- A GitHub Action attribution: `actor=github-actions[bot]` (any timing).
- Native CODEOWNERS attribution: `actor=<PR author>`, event timestamp exactly matches PR `created_at`.

Manual requests by the PR author (clicked later, including 13s after open) and any request by a non-author land in the "manual" bucket and stay visible.

### Known limitation
CODEOWNERS can also re-evaluate on a *push* that adds owned files. The resulting event fires at push time (not PR creation), so we'd miss those (false negative). Detecting them would require pairing the request event with a nearby push event — not worth the complexity for now.

## Caching
Each fresh fetch would otherwise add one timeline API call per review-requested PR. `autoAssigned` only changes when the PR changes (push, comment, review — all bump `updated_at`), so we cache `{value, updatedAt}` per `(instance, repo, prNumber)` and skip the timeline fetch when the cached `updatedAt` still matches. Transient timeline failures don't poison the cache.

## Changes
- **Server (`fetchers.ts`)**: each review gets an `autoAssigned` flag (replaces the prior `requestedDirectly`). Adds one timeline fetch per review-requested PR, in parallel with the existing CI/reviews/PR calls. Cached per PR keyed on `updated_at`.
- **Web (`filters.ts`)**: atom renamed to `showCodeOwnerRequestsAtom`, new localStorage key, default `true` (same UX).
- **Web (`App.tsx`)**: filter predicate updated; switch label "Code owners" lives between the column header and sort dimensions. `f` keyboard shortcut toggles it (Reviews column only).
- **Dashboard polish (came up while wiring this)**: "My PRs" → "My work", "Review Requests" → "Reviews"; My work count now reflects open PRs only; `SortControl` renders just the active dimension.

## Tests
Server suite covers the autoAssigned branches and the cache end-to-end (`fetchers.integration.test.ts`):
- direct path: PR-author at creation, PR-author within 2s (boundary), PR-author >2s, PR-author much later, non-author human, Bot-type actor, `[bot]`-suffix actor without type, mixed events, empty timeline
- team path: PR-author at creation, PR-author >2s, non-author human, Bot actor
- fallbacks: timeline 404, event missing `created_at`
- caching: hit short-circuits timeline fetch, miss refetches, failure doesn't write, miss-then-populate

107 server tests pass (was 91 on `main`).

## Follow-up
Surfaced #46 — keyboard-shortcut scope is implicit today and the help overlay doesn't communicate it.

## Test plan
- [x] `pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm fmt:check`
- [x] Toggle in column header changes count against real data
- [x] `f` shortcut fires only when Reviews column is focused
- [x] Atom default is `true` (existing users see all reviews unchanged)
- [x] `s` still cycles sort dimensions