### PR TITLE
desktop-release: surface .dmg links + auto-changelog in notes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -138,3 +138,32 @@ jobs:
         run: gh release edit "${{ needs.bump.outputs.ref }}" --draft=false --prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build a friendlier release body: direct .dmg links up top + GitHub's
+      # auto-generated commit list below. The raw asset list (zips, blockmaps,
+      # latest-mac.yml) still renders below the body, but most users only see
+      # the .dmg link now.
+      - name: Write release notes
+        run: |
+          set -euo pipefail
+          tag="${{ needs.bump.outputs.ref || github.ref_name }}"
+          version="${tag#v}"
+          repo="${{ github.repository }}"
+          base_url="https://github.com/${repo}/releases/download/${tag}"
+          changelog=$(gh api -X POST "/repos/${repo}/releases/generate-notes" \
+            -f tag_name="$tag" --jq '.body')
+          {
+            echo "## Download"
+            echo
+            echo "- **Apple Silicon (M1/M2/M3/M4):** [GitHub-Dashboard-${version}-arm64.dmg](${base_url}/GitHub-Dashboard-${version}-arm64.dmg)"
+            echo "- **Intel:** [GitHub-Dashboard-${version}.dmg](${base_url}/GitHub-Dashboard-${version}.dmg)"
+            echo
+            echo "Other files in the asset list are consumed by the in-app auto-updater."
+            echo
+            echo "---"
+            echo
+            echo "$changelog"
+          } > /tmp/notes.md
+          gh release edit "$tag" --notes-file /tmp/notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `Write release notes` step to `desktop-release.yml` that runs after the publish/promote steps.
- Notes body has a **Download** section with direct links to the arm64 and x64 `.dmg` files, then a horizontal rule, then GitHub's auto-generated `What's Changed` / `New Contributors` / `Full Changelog` section.
- Backfilled `v0.0.1` manually so the current release already shows the new format.

## Test plan
- [ ] Next `rc` or `release` workflow run produces a release whose body opens with the Download section and is followed by the auto-changelog.
- [ ] Raw asset list (zips, blockmaps, `latest-mac.yml`) still renders below — those stay because electron-updater needs them.