### PR TITLE
reviews: classify the current attachment, not historical events

### DIFF
--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -452,6 +452,43 @@ describe("fetchReviews — autoAssigned", () => {
       });
       expect(await getAutoAssigned()).toBe(false);
     });
+
+    it("manual when an auto request was removed and the user was manually re-requested", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          // CODEOWNERS auto-attaches the user at PR creation.
+          direct({ login: PR_AUTHOR }, PR_CREATED_AT),
+          // The user is removed.
+          {
+            event: "review_request_removed",
+            actor: { login: USERNAME },
+            requested_reviewer: { login: USERNAME },
+            created_at: "2026-01-01T01:00:00Z",
+          },
+          // A non-author manually re-requests them later.
+          direct({ login: "dave" }, "2026-01-01T02:00:00Z"),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(false);
+    });
+
+    it("auto when a manual request was removed and a bot re-attached the user", async () => {
+      setup({
+        requestedReviewers: [{ login: USERNAME }],
+        timeline: [
+          direct({ login: "dave" }, "2026-01-01T01:00:00Z"),
+          {
+            event: "review_request_removed",
+            actor: { login: USERNAME },
+            requested_reviewer: { login: USERNAME },
+            created_at: "2026-01-01T02:00:00Z",
+          },
+          direct({ login: "github-actions[bot]" }, "2026-01-01T03:00:00Z"),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(true);
+    });
   });
 
   describe("team path (user only via team membership)", () => {
@@ -505,6 +542,23 @@ describe("fetchReviews — autoAssigned", () => {
         ],
       });
       expect(await getAutoAssigned()).toBe(true);
+    });
+
+    it("manual when an auto team request was removed and a human re-requested the team", async () => {
+      setup({
+        ...teamSetup,
+        timeline: [
+          team({ login: PR_AUTHOR }, PR_CREATED_AT),
+          {
+            event: "review_request_removed",
+            actor: { login: "dave" },
+            requested_team: { slug: "platform" },
+            created_at: "2026-01-01T01:00:00Z",
+          },
+          team({ login: "dave" }, "2026-01-01T02:00:00Z"),
+        ],
+      });
+      expect(await getAutoAssigned()).toBe(false);
     });
   });
 

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -362,6 +362,11 @@ export async function fetchReviews(instanceId: string) {
       //     as the PR was opened (within 2s).
       // Manual requests by the PR author (later clicks of "Request review")
       // share the actor but not the timing, so they correctly stay visible.
+      //
+      // We classify the *current* attachment per reviewer/team — i.e. the most
+      // recent `review_requested` event not superseded by a
+      // `review_request_removed`. This way a CODEOWNERS auto-attach that was
+      // removed and then manually re-requested is correctly counted as manual.
       let autoAssigned: boolean;
       if (useCachedAuto && cachedAuto) {
         autoAssigned = cachedAuto.value;
@@ -373,13 +378,14 @@ export async function fetchReviews(instanceId: string) {
         const inRequestedReviewers =
           prData?.requested_reviewers?.some((r) => r?.login === username) ??
           false;
-        const timelineEvents = (timelineRes?.data ?? []) as Array<{
+        type TimelineEvent = {
           event?: string;
           created_at?: string;
           actor?: { login?: string; type?: string } | null;
           requested_reviewer?: { login?: string } | null;
           requested_team?: { slug?: string } | null;
-        }>;
+        };
+        const timelineEvents = (timelineRes?.data ?? []) as TimelineEvent[];
         const isAutoActor = (
           actor: { login?: string; type?: string } | null | undefined,
           eventCreatedAt?: string,
@@ -391,19 +397,30 @@ export async function fetchReviews(instanceId: string) {
           if (prCreatedMs == null || !eventCreatedAt) return false;
           return Math.abs(Date.parse(eventCreatedAt) - prCreatedMs) <= 2000;
         };
-        autoAssigned = inRequestedReviewers
-          ? timelineEvents.some(
-              (ev) =>
-                ev.event === "review_requested" &&
-                ev.requested_reviewer?.login === username &&
-                isAutoActor(ev.actor, ev.created_at),
-            )
-          : timelineEvents.some(
-              (ev) =>
-                ev.event === "review_requested" &&
-                ev.requested_team != null &&
-                isAutoActor(ev.actor, ev.created_at),
-            );
+        // Walk in chronological order (the timeline API returns events in
+        // order). The latest `review_requested` not followed by a matching
+        // `review_request_removed` is the current attachment.
+        const currentReviewerAttachment = new Map<string, TimelineEvent>();
+        const currentTeamAttachment = new Map<string, TimelineEvent>();
+        for (const ev of timelineEvents) {
+          const reviewer = ev.requested_reviewer?.login;
+          const team = ev.requested_team?.slug;
+          if (ev.event === "review_requested") {
+            if (reviewer) currentReviewerAttachment.set(reviewer, ev);
+            if (team) currentTeamAttachment.set(team, ev);
+          } else if (ev.event === "review_request_removed") {
+            if (reviewer) currentReviewerAttachment.delete(reviewer);
+            if (team) currentTeamAttachment.delete(team);
+          }
+        }
+        if (inRequestedReviewers) {
+          const ev = currentReviewerAttachment.get(username);
+          autoAssigned = ev != null && isAutoActor(ev.actor, ev.created_at);
+        } else {
+          autoAssigned = [...currentTeamAttachment.values()].some((ev) =>
+            isAutoActor(ev.actor, ev.created_at),
+          );
+        }
         // Only persist when the timeline fetch actually succeeded — a 404 /
         // throttle shouldn't burn a "false" into the cache and shadow a real
         // auto-assignment.

--- a/packages/web/src/components/ShortcutHelp.tsx
+++ b/packages/web/src/components/ShortcutHelp.tsx
@@ -36,7 +36,7 @@ const sections: { title: string; shortcuts: [string, string][] }[] = [
       ["a", "Approve PR"],
       ["c", "Close PR"],
       ["e", "Dismiss review / notification"],
-      ["f", "Toggle CODEOWNERS-attached reviews"],
+      ["f", "Toggle CODEOWNERS-attached reviews (Reviews column)"],
       ["s", "Cycle sort dimension"],
       ["S", "Toggle sort direction"],
     ],


### PR DESCRIPTION
Follow-up to #44 addressing two Copilot review comments left after merge.

## 1. autoAssigned should reflect the *current* attachment

[Comment](https://github.com/AntonNiklasson/github-dashboard/pull/44#discussion_r3266501674) on `fetchers.ts`:

> `autoAssigned` uses `some(...)` over all timeline events, so a historical auto request (e.g., CODEOWNERS at creation) will keep `autoAssigned=true` even if the request was later removed and re-requested manually.

Walk the timeline in chronological order and track the latest `review_requested` event per reviewer/team that hasn't been superseded by a `review_request_removed`. Classify only that "current attachment" event. Same class of mistake as the false-positive case we fixed in #44 — we were looking at history instead of state.

New tests cover the two remove/re-add scenarios for both the direct and team paths.

## 2. `f` shortcut help text didn't reflect its scope

[Comment](https://github.com/AntonNiklasson/github-dashboard/pull/44#discussion_r3266501842) on `ShortcutHelp.tsx`:

> The help text lists `f` as a general action ("Toggle CODEOWNERS-attached reviews"), but the handler is scoped to `activeSection === "reviews"`. Update the description to reflect that scope.

One-line description update. Broader help-overlay-scope structure tracked in #46.

## Not addressing
[Comment](https://github.com/AntonNiklasson/github-dashboard/pull/44#discussion_r3266501788) on `SortControl.tsx` about empty-fields safety — every call site passes a literal constant, so the failure mode is theoretical. Skipping unless it becomes a real concern.

## Test plan
- [x] `pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm fmt:check`
- [x] 110 server tests pass (was 107)