### PR TITLE
notifications: rewrite subject API URLs to their HTML form

### DIFF
--- a/.claude/skills/review-pr-comments/SKILL.md
+++ b/.claude/skills/review-pr-comments/SKILL.md
@@ -47,7 +47,7 @@ Do this research in parallel across comments where possible (use the Task tool f
 
 ## Step 3: Present assessment
 
-Use `EnterPlanMode` to present results. Lead with the summary, then group by verdict.
+Lead with the summary, then group by verdict.
 
 ### Output format
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ enterprise:
 
 Tokens can also be updated from the settings modal in the UI.
 
+## Notifications
+
+The Notifications column is intentionally narrower than GitHub's own inbox — it drops items that are either already represented elsewhere in the dashboard or are pure noise:
+
+| Reason | Subject | Why it's dropped |
+|---|---|---|
+| `review_requested` | any | Shown in the Reviews column |
+| `ci_activity` | any | Visible on the PR itself |
+| `author` | `PullRequest` | Your own PR, shown in My work |
+| `state_change` | `PullRequest` | Your own PR, shown in My work / Reviews |
+| `subscribed` | any | Auto-subscription noise |
+
+Everything else (mentions, team mentions, assignments, comments on threads you participate in, security alerts, …) flows through unchanged.
+
 ## Architecture
 
 ```mermaid

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -231,52 +231,95 @@ describe("fetchRecentPrs", () => {
 });
 
 describe("fetchNotifications", () => {
-  it("omits review_requested notifications", async () => {
-    mockOctokit.activity.listNotificationsForAuthenticatedUser.mockResolvedValue(
+  // fetchNotifications fans out across multiple pages — first call returns
+  // the test data, subsequent pages are empty.
+  const setNotifications = (data: unknown[]) => {
+    mockOctokit.activity.listNotificationsForAuthenticatedUser
+      .mockResolvedValueOnce({ data })
+      .mockResolvedValue({ data: [] });
+  };
+
+  it("omits notifications already represented elsewhere in the dashboard", async () => {
+    setNotifications([
       {
-        data: [
-          {
-            id: "1",
-            subject: { title: "x", type: "PullRequest", url: "http://x" },
-            reason: "mention",
-            repository: { full_name: "o/r" },
-            updated_at: "2026-01-01T00:00:00Z",
-            unread: true,
-          },
-          {
-            id: "2",
-            subject: { title: "y", type: "PullRequest", url: "http://y" },
-            reason: "review_requested",
-            repository: { full_name: "o/r" },
-            updated_at: "2026-01-02T00:00:00Z",
-            unread: true,
-          },
-        ],
+        id: "keep-mention",
+        subject: { title: "x", type: "PullRequest", url: "http://x" },
+        reason: "mention",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-01T00:00:00Z",
+        unread: true,
       },
-    );
+      {
+        id: "keep-author-issue",
+        subject: { title: "issue I opened", type: "Issue", url: "http://i" },
+        reason: "author",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-01T00:00:00Z",
+        unread: true,
+      },
+      {
+        id: "drop-review-requested",
+        subject: { title: "y", type: "PullRequest", url: "http://y" },
+        reason: "review_requested",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-02T00:00:00Z",
+        unread: true,
+      },
+      {
+        id: "drop-ci",
+        subject: { title: "z", type: "CheckSuite", url: null },
+        reason: "ci_activity",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-03T00:00:00Z",
+        unread: true,
+      },
+      {
+        id: "drop-author-pr",
+        subject: { title: "my pr", type: "PullRequest", url: "http://p" },
+        reason: "author",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-04T00:00:00Z",
+        unread: true,
+      },
+      {
+        id: "drop-state-change-pr",
+        subject: { title: "merged pr", type: "PullRequest", url: "http://m" },
+        reason: "state_change",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-05T00:00:00Z",
+        unread: true,
+      },
+      {
+        id: "drop-subscribed",
+        subject: { title: "sub", type: "Issue", url: "http://s" },
+        reason: "subscribed",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-06T00:00:00Z",
+        unread: true,
+      },
+    ]);
     const notifs = await fetchNotifications("github");
-    expect(notifs.map((n) => n.id)).toEqual(["1"]);
+    expect(notifs.map((n) => n.id)).toEqual([
+      "keep-mention",
+      "keep-author-issue",
+    ]);
   });
 
   it("shapes the payload for the UI and rewrites the subject URL to its HTML form", async () => {
-    mockOctokit.activity.listNotificationsForAuthenticatedUser.mockResolvedValue(
+    setNotifications([
       {
-        data: [
-          {
-            id: "1",
-            subject: {
-              title: "hello",
-              type: "Issue",
-              url: "https://api.github.com/repos/o/r/issues/42",
-            },
-            reason: "mention",
-            repository: { full_name: "o/r" },
-            updated_at: "2026-01-01T00:00:00Z",
-            unread: false,
-          },
-        ],
+        id: "1",
+        subject: {
+          title: "hello",
+          type: "Issue",
+          url: "https://api.github.com/repos/o/r/issues/42",
+        },
+        reason: "mention",
+        repository: { full_name: "o/r" },
+        updated_at: "2026-01-01T00:00:00Z",
+        unread: false,
       },
-    );
+    ]);
     const [n] = await fetchNotifications("github");
     expect(n).toEqual({
       id: "1",
@@ -288,6 +331,27 @@ describe("fetchNotifications", () => {
       unread: false,
       url: "https://github.com/o/r/issues/42",
     });
+  });
+
+  it("fans out across multiple pages and merges the results", async () => {
+    const make = (id: string) => ({
+      id,
+      subject: { title: id, type: "Issue", url: `http://i/${id}` },
+      reason: "mention",
+      repository: { full_name: "o/r" },
+      updated_at: "2026-01-01T00:00:00Z",
+      unread: true,
+    });
+    mockOctokit.activity.listNotificationsForAuthenticatedUser
+      .mockResolvedValueOnce({ data: [make("p1-a"), make("p1-b")] })
+      .mockResolvedValueOnce({ data: [make("p2-a")] })
+      .mockResolvedValueOnce({ data: [make("p3-a")] });
+
+    const notifs = await fetchNotifications("github");
+    expect(notifs.map((n) => n.id)).toEqual(["p1-a", "p1-b", "p2-a", "p3-a"]);
+    expect(
+      mockOctokit.activity.listNotificationsForAuthenticatedUser,
+    ).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -365,6 +429,78 @@ describe("notificationHtmlUrl", () => {
     expect(notificationHtmlUrl("not a url", "Issue", "o/r", apiBase)).toBe(
       "https://github.com/o/r",
     );
+  });
+
+  it("appends an issuecomment fragment when latest_comment_url points at an issue comment", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/issues/42",
+        "Issue",
+        "o/r",
+        apiBase,
+        "https://api.github.com/repos/o/r/issues/comments/9001",
+      ),
+    ).toBe("https://github.com/o/r/issues/42#issuecomment-9001");
+  });
+
+  it("appends a discussion_r fragment for PR review comments", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/pulls/7",
+        "PullRequest",
+        "o/r",
+        apiBase,
+        "https://api.github.com/repos/o/r/pulls/comments/555",
+      ),
+    ).toBe("https://github.com/o/r/pull/7#discussion_r555");
+  });
+
+  it("appends a commitcomment fragment for commit comments", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/commits/abc",
+        "Commit",
+        "o/r",
+        apiBase,
+        "https://api.github.com/repos/o/r/comments/77",
+      ),
+    ).toBe("https://github.com/o/r/commit/abc#commitcomment-77");
+  });
+
+  it("handles GHES comment URLs by stripping the /api/v3 prefix", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://ghe.example.com/api/v3/repos/o/r/pulls/7",
+        "PullRequest",
+        "o/r",
+        "https://ghe.example.com/api/v3",
+        "https://ghe.example.com/api/v3/repos/o/r/issues/comments/12",
+      ),
+    ).toBe("https://ghe.example.com/o/r/pull/7#issuecomment-12");
+  });
+
+  it("ignores latest_comment_url when it doesn't match a known shape", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/issues/42",
+        "Issue",
+        "o/r",
+        apiBase,
+        "https://api.github.com/repos/o/r/reviews/9001",
+      ),
+    ).toBe("https://github.com/o/r/issues/42");
+  });
+
+  it("does not append a comment fragment when falling back to a list page (Release)", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/releases/999",
+        "Release",
+        "o/r",
+        apiBase,
+        "https://api.github.com/repos/o/r/issues/comments/9001",
+      ),
+    ).toBe("https://github.com/o/r/releases");
   });
 });
 

--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -18,7 +18,7 @@ vi.mock("./github-client.js", () => ({
   getInstance: async (id: string) => ({
     id,
     label: id,
-    baseUrl: "",
+    baseUrl: "https://api.github.com",
     token: "t",
     username: "alice",
   }),
@@ -37,8 +37,13 @@ vi.mock("./cache.js", () => ({
   },
 }));
 
-const { fetchPrs, fetchNotifications, fetchRecentPrs, fetchReviews } =
-  await import("./fetchers.js");
+const {
+  fetchPrs,
+  fetchNotifications,
+  fetchRecentPrs,
+  fetchReviews,
+  notificationHtmlUrl,
+} = await import("./fetchers.js");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -253,13 +258,17 @@ describe("fetchNotifications", () => {
     expect(notifs.map((n) => n.id)).toEqual(["1"]);
   });
 
-  it("shapes the payload for the UI", async () => {
+  it("shapes the payload for the UI and rewrites the subject URL to its HTML form", async () => {
     mockOctokit.activity.listNotificationsForAuthenticatedUser.mockResolvedValue(
       {
         data: [
           {
             id: "1",
-            subject: { title: "hello", type: "Issue", url: "http://x" },
+            subject: {
+              title: "hello",
+              type: "Issue",
+              url: "https://api.github.com/repos/o/r/issues/42",
+            },
             reason: "mention",
             repository: { full_name: "o/r" },
             updated_at: "2026-01-01T00:00:00Z",
@@ -277,8 +286,85 @@ describe("fetchNotifications", () => {
       repo: "o/r",
       updatedAt: "2026-01-01T00:00:00Z",
       unread: false,
-      url: "http://x",
+      url: "https://github.com/o/r/issues/42",
     });
+  });
+});
+
+describe("notificationHtmlUrl", () => {
+  const apiBase = "https://api.github.com";
+
+  it("rewrites issue API URLs to HTML form", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/issues/42",
+        "Issue",
+        "o/r",
+        apiBase,
+      ),
+    ).toBe("https://github.com/o/r/issues/42");
+  });
+
+  it("rewrites pulls API URLs (pulls → pull) for PRs", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/pulls/123",
+        "PullRequest",
+        "o/r",
+        apiBase,
+      ),
+    ).toBe("https://github.com/o/r/pull/123");
+  });
+
+  it("rewrites commits API URLs (commits → commit)", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/commits/abc123",
+        "Commit",
+        "o/r",
+        apiBase,
+      ),
+    ).toBe("https://github.com/o/r/commit/abc123");
+  });
+
+  it("falls back to the repo's releases page for Release subjects (the ID isn't UI-routable)", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://api.github.com/repos/o/r/releases/999",
+        "Release",
+        "o/r",
+        apiBase,
+      ),
+    ).toBe("https://github.com/o/r/releases");
+  });
+
+  it("falls back to the repo's discussions page when subject.url is missing (Discussion)", () => {
+    expect(notificationHtmlUrl(null, "Discussion", "o/r", apiBase)).toBe(
+      "https://github.com/o/r/discussions",
+    );
+  });
+
+  it("falls back to the repo page when subject.url is missing and type is unknown", () => {
+    expect(notificationHtmlUrl(null, "CheckSuite", "o/r", apiBase)).toBe(
+      "https://github.com/o/r",
+    );
+  });
+
+  it("handles GHES URLs by stripping the /api/v3 prefix and keeping the host", () => {
+    expect(
+      notificationHtmlUrl(
+        "https://ghe.example.com/api/v3/repos/o/r/pulls/7",
+        "PullRequest",
+        "o/r",
+        "https://ghe.example.com/api/v3",
+      ),
+    ).toBe("https://ghe.example.com/o/r/pull/7");
+  });
+
+  it("falls back to the repo page when subject.url is unparseable", () => {
+    expect(notificationHtmlUrl("not a url", "Issue", "o/r", apiBase)).toBe(
+      "https://github.com/o/r",
+    );
   });
 });
 

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -472,6 +472,10 @@ export async function fetchReviews(instanceId: string) {
 // The notifications API returns the subject's API URL on `subject.url` and
 // doesn't include an `html_url`, so we have to derive it ourselves.
 //
+// When `latestCommentUrl` is set, we append the matching fragment so the
+// link opens at the comment (e.g. #issuecomment-123) rather than the top
+// of the thread.
+//
 // Handles github.com and GHES (where the API lives under `/api/v3`).
 // For subjects that don't have a usable URL (e.g. Discussion) or types we
 // can't address precisely (Release IDs aren't routable in the UI), we fall
@@ -481,6 +485,7 @@ export function notificationHtmlUrl(
   type: string | null | undefined,
   repoFullName: string,
   apiBaseUrl: string,
+  latestCommentUrl?: string | null,
 ): string {
   const htmlBase = htmlBaseFromApiBase(apiBaseUrl);
   const repoUrl = `${htmlBase}/${repoFullName}`;
@@ -503,11 +508,37 @@ export function notificationHtmlUrl(
     .replace(/^\/([^/]+\/[^/]+)\/pulls\//, "/$1/pull/")
     .replace(/^\/([^/]+\/[^/]+)\/commits\//, "/$1/commit/");
   // Release notification subjects point at /releases/{id}, which the GitHub
-  // UI doesn't route. Fall back to the repo's releases list.
+  // UI doesn't route. Fall back to the repo's releases list — the comment
+  // fragment isn't meaningful on that page either.
   const releaseMatch = path.match(/^\/([^/]+\/[^/]+)\/releases\/\d+$/);
-  if (releaseMatch) path = `/${releaseMatch[1]}/releases`;
+  if (releaseMatch) return `${htmlBase}/${releaseMatch[1]}/releases`;
 
-  return `${htmlBase}${path}`;
+  const fragment = commentFragment(latestCommentUrl);
+  return `${htmlBase}${path}${fragment ?? ""}`;
+}
+
+// Map a comment's API URL to the matching HTML page fragment so the link
+// scrolls to the comment. Returns null for shapes we don't recognise — the
+// caller then renders the bare thread URL.
+function commentFragment(
+  commentApiUrl: string | null | undefined,
+): string | null {
+  if (!commentApiUrl) return null;
+  let path: string;
+  try {
+    path = new URL(commentApiUrl).pathname;
+  } catch {
+    return null;
+  }
+  path = path.replace(/^\/api\/v3/, "");
+  let m: RegExpMatchArray | null;
+  if ((m = path.match(/\/issues\/comments\/(\d+)$/)))
+    return `#issuecomment-${m[1]}`;
+  if ((m = path.match(/\/pulls\/comments\/(\d+)$/)))
+    return `#discussion_r${m[1]}`;
+  if ((m = path.match(/\/repos\/[^/]+\/[^/]+\/comments\/(\d+)$/)))
+    return `#commitcomment-${m[1]}`;
+  return null;
 }
 
 function htmlBaseFromApiBase(apiBaseUrl: string): string {
@@ -520,17 +551,56 @@ function htmlBaseFromApiBase(apiBaseUrl: string): string {
   }
 }
 
+// Notifications already represented elsewhere in the dashboard (My work,
+// Reviews, the PR itself) or that are pure noise. Dropping them at the
+// fetcher keeps the Notifications column focused on things that aren't
+// surfaced anywhere else.
+type NotificationShape = {
+  reason: string;
+  subject: { type: string | null };
+};
+
+const redundantRules: ReadonlyArray<(n: NotificationShape) => boolean> = [
+  // shown in the Reviews column
+  (n) => n.reason === "review_requested",
+  // visible on the PR itself
+  (n) => n.reason === "ci_activity",
+  // your own PR, shown in My work
+  (n) => n.subject.type === "PullRequest" && n.reason === "author",
+  // your own PR, shown in My work / Reviews
+  (n) => n.subject.type === "PullRequest" && n.reason === "state_change",
+  // auto-subscription noise
+  (n) => n.reason === "subscribed",
+];
+
+function isRedundantNotification(n: NotificationShape): boolean {
+  return redundantRules.some((rule) => rule(n));
+}
+
+// We pull a few pages so the filter has enough raw material — many items
+// are dropped as redundant (review_requested, ci_activity, …), and a single
+// page often leaves the kept set sparse. Pages are fetched in parallel; the
+// result is cached, so this only fires on cache miss / explicit refresh.
+const NOTIFICATION_PAGES = 3;
+const NOTIFICATIONS_PER_PAGE = 50;
+
 export async function fetchNotifications(instanceId: string) {
   const client = await getClient(instanceId);
   const { baseUrl } = await getInstance(instanceId);
 
-  const { data } = await client.activity.listNotificationsForAuthenticatedUser({
-    all: true,
-    per_page: 30,
-  });
+  const pages = await Promise.all(
+    Array.from({ length: NOTIFICATION_PAGES }, (_, i) =>
+      client.activity.listNotificationsForAuthenticatedUser({
+        all: true,
+        per_page: NOTIFICATIONS_PER_PAGE,
+        page: i + 1,
+      }),
+    ),
+  );
+  const data = pages.flatMap((r) => r.data);
 
   return data
-    .filter((n) => n.reason !== "review_requested")
+    .filter((n) => !isRedundantNotification(n))
     .map((n) => ({
       id: n.id,
       title: n.subject.title,
@@ -544,6 +614,7 @@ export async function fetchNotifications(instanceId: string) {
         n.subject.type,
         n.repository.full_name,
         baseUrl,
+        n.subject.latest_comment_url,
       ),
     }));
 }

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -467,8 +467,62 @@ export async function fetchReviews(instanceId: string) {
   );
 }
 
+// Convert a GitHub *API* URL (e.g. https://api.github.com/repos/o/r/pulls/1)
+// into its corresponding *HTML* URL (https://github.com/o/r/pull/1).
+// The notifications API returns the subject's API URL on `subject.url` and
+// doesn't include an `html_url`, so we have to derive it ourselves.
+//
+// Handles github.com and GHES (where the API lives under `/api/v3`).
+// For subjects that don't have a usable URL (e.g. Discussion) or types we
+// can't address precisely (Release IDs aren't routable in the UI), we fall
+// back to a sensible repo-level page.
+export function notificationHtmlUrl(
+  apiUrl: string | null | undefined,
+  type: string | null | undefined,
+  repoFullName: string,
+  apiBaseUrl: string,
+): string {
+  const htmlBase = htmlBaseFromApiBase(apiBaseUrl);
+  const repoUrl = `${htmlBase}/${repoFullName}`;
+
+  if (!apiUrl) {
+    if (type === "Discussion") return `${repoUrl}/discussions`;
+    if (type === "Release") return `${repoUrl}/releases`;
+    return repoUrl;
+  }
+
+  let path: string;
+  try {
+    path = new URL(apiUrl).pathname;
+  } catch {
+    return repoUrl;
+  }
+
+  path = path.replace(/^\/api\/v3\/repos\//, "/").replace(/^\/repos\//, "/");
+  path = path
+    .replace(/^\/([^/]+\/[^/]+)\/pulls\//, "/$1/pull/")
+    .replace(/^\/([^/]+\/[^/]+)\/commits\//, "/$1/commit/");
+  // Release notification subjects point at /releases/{id}, which the GitHub
+  // UI doesn't route. Fall back to the repo's releases list.
+  const releaseMatch = path.match(/^\/([^/]+\/[^/]+)\/releases\/\d+$/);
+  if (releaseMatch) path = `/${releaseMatch[1]}/releases`;
+
+  return `${htmlBase}${path}`;
+}
+
+function htmlBaseFromApiBase(apiBaseUrl: string): string {
+  try {
+    const u = new URL(apiBaseUrl);
+    if (u.hostname === "api.github.com") return "https://github.com";
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "https://github.com";
+  }
+}
+
 export async function fetchNotifications(instanceId: string) {
   const client = await getClient(instanceId);
+  const { baseUrl } = await getInstance(instanceId);
 
   const { data } = await client.activity.listNotificationsForAuthenticatedUser({
     all: true,
@@ -485,6 +539,11 @@ export async function fetchNotifications(instanceId: string) {
       repo: n.repository.full_name,
       updatedAt: n.updated_at,
       unread: n.unread,
-      url: n.subject.url,
+      url: notificationHtmlUrl(
+        n.subject.url,
+        n.subject.type,
+        n.repository.full_name,
+        baseUrl,
+      ),
     }));
 }


### PR DESCRIPTION
A handful of related improvements to the Notifications column.

### Rewrite subject API URLs to their HTML form

The notifications API returns `subject.url` as an API URL (e.g. `https://api.github.com/repos/o/r/pulls/1`) and doesn't include an `html_url`, so pressing `o` was opening a raw JSON endpoint. Derive the HTML URL locally — no extra API calls — and fall back to a sensible repo-level page for subject types we can't resolve precisely (`Release`, `Discussion`).

### Open at the active comment

When `subject.latest_comment_url` is set, append the matching fragment so the link scrolls to the comment instead of the top of the thread:

- `issues/comments/N` → `#issuecomment-N`
- `pulls/comments/N` → `#discussion_rN`
- `repos/.../comments/N` → `#commitcomment-N`

Matches GitHub's own inbox behaviour.

### Filter types already represented elsewhere

Drop reasons that are either already shown elsewhere in the dashboard or are noise:

| Reason | Subject | Why |
|---|---|---|
| `review_requested` | any | Reviews column |
| `ci_activity` | any | Visible on the PR itself |
| `author` | `PullRequest` | My work |
| `state_change` | `PullRequest` | My work / Reviews |
| `subscribed` | any | Auto-subscription noise |

Implemented as a small table of predicates so new exclusions are one-liners. README updated with the same table.

### Fetch a few pages

Single page of 30 left the kept set sparse after filtering. Now fans out across 3 pages × 50 (the API max) in parallel and merges — the cache layer is unchanged, so this only fires on cache miss / explicit refresh.

Fixes #47