### PR TITLE
dev: let Electron orchestrate random ports for server + Vite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent notes
 
-Monorepo: `packages/server` (Hono API, port 7100) + `packages/web` (Vite/React, port 7200, proxies `/api` to server).
+Monorepo: `packages/server` (Hono API) + `packages/web` (Vite/React, proxies `/api` to server) + `packages/desktop` (Electron). Electron is the dev orchestrator: `pnpm dev` builds the Electron main and launches it, which picks two free ports and spawns the server and Vite as children. Vite's `/api` proxy reads `GHD_API_PORT`. The current dev URL + ports are written to `.logs/ports.json` on startup.
 
 ## Validating your own work
 
@@ -10,11 +10,11 @@ Close the loop before declaring done. Available tools:
 - `pnpm test` — vitest in both packages
 - `pnpm lint` — oxlint
 - `pnpm fmt:check` — oxfmt
-- `pnpm dev` — runs server + web concurrently (long-running; start in background). Stdout/stderr is tee'd to `.logs/server.log` and `.logs/web.log` — tail or read these to inspect output. Logs reset on each start; accumulate across hot reloads within a session.
+- `pnpm dev` — Electron orchestrates server + Vite on random ports (long-running; start in background). Stdout/stderr is tee'd to `.logs/server.log`, `.logs/web.log`, and `.logs/desktop.log` — tail or read these to inspect output. Logs reset on each start; accumulate across hot reloads within a session.
 
-For UI/UX changes, type-checks aren't enough — drive the app via the **Playwright MCP** (`.mcp.json`):
+For UI/UX changes, type-checks aren't enough — drive the app via the **Playwright MCP** (`.mcp.json`). Read `.logs/ports.json` first to discover the current dev URL (ports are random each session):
 
-- `browser_navigate` to `http://localhost:7200`
+- `browser_navigate` to the `url` from `.logs/ports.json`
 - `browser_snapshot` for the accessibility tree (preferred over screenshots for assertions)
 - `browser_click`, `browser_type`, `browser_press_key` to exercise keyboard shortcuts
 - `browser_console_messages` to catch runtime errors

--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
   "private": true,
   "packageManager": "pnpm@10.29.3",
   "scripts": {
-    "dev": "mkdir -p .logs && concurrently -n server,web -c blue,green \"pnpm --filter @github-dashboard/server dev 2>&1 | tee .logs/server.log\" \"pnpm --filter @github-dashboard/web dev 2>&1 | tee .logs/web.log\"",
-    "dev:desktop": "mkdir -p .logs && pnpm --filter @github-dashboard/desktop build && concurrently -n server,web,desktop -c blue,green,magenta \"pnpm --filter @github-dashboard/server dev 2>&1 | tee .logs/server.log\" \"pnpm --filter @github-dashboard/web dev 2>&1 | tee .logs/web.log\" \"wait-on http://localhost:7200 && pnpm --filter @github-dashboard/desktop dev 2>&1 | tee .logs/desktop.log\"",
+    "dev": "mkdir -p .logs && pnpm --filter @github-dashboard/desktop build && pnpm --filter @github-dashboard/desktop dev 2>&1 | tee .logs/desktop.log",
     "demo": "DEMO=1 pnpm dev",
-    "demo:desktop": "DEMO=1 pnpm dev:desktop",
     "build": "pnpm --filter @github-dashboard/server build && pnpm --filter @github-dashboard/web build",
     "build:desktop": "pnpm build && pnpm --filter @github-dashboard/desktop build && pnpm --filter @github-dashboard/desktop package",
     "lint": "oxlint",
@@ -18,12 +16,10 @@
   },
   "devDependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260420.1",
-    "concurrently": "^9.1.2",
     "husky": "^9.1.7",
     "oxfmt": "^0.7.0",
     "oxlint": "^0.16.10",
-    "typescript": "^6.0.2",
-    "wait-on": "^8.0.1"
+    "typescript": "^6.0.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,10 +1,15 @@
 import { BrowserWindow, Menu, app, ipcMain, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import { autoUpdater } from "electron-updater";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createWriteStream, mkdirSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
-const DEV_WEB_URL = "http://localhost:7200";
+// In dev, the repo root is three levels up from packages/desktop/dist (where
+// main.js lives after tsgo compiles it).
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const LOGS_DIR = path.join(REPO_ROOT, ".logs");
 
 // In dev, `app.name` defaults to the package.json `name` ("@github-dashboard/
 // desktop"), which surfaces as "Electron" in the macOS app menu. Force it
@@ -13,6 +18,8 @@ app.setName("GitHub Dashboard");
 
 let mainWindow: BrowserWindow | null = null;
 let serverPort = 0;
+let devServerProc: ChildProcess | null = null;
+let devWebProc: ChildProcess | null = null;
 
 async function findFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -39,22 +46,101 @@ async function startEmbeddedServer(): Promise<void> {
   // Importing has the side effect of starting the Hono server. The bundle
   // lives at Resources/server.mjs (see extraResources in package.json).
   await import(path.join(process.resourcesPath, "server.mjs"));
-  await waitForServer();
+  await waitForUrl(`http://localhost:${serverPort}/api/instances`);
 }
 
-async function waitForServer(): Promise<void> {
-  const url = `http://localhost:${serverPort}/api/instances`;
-  const deadline = Date.now() + 10_000;
+function tee(proc: ChildProcess, file: string): void {
+  const out = createWriteStream(path.join(LOGS_DIR, file), { flags: "w" });
+  proc.stdout?.pipe(out, { end: false });
+  proc.stderr?.pipe(out, { end: false });
+  proc.stdout?.pipe(process.stdout, { end: false });
+  proc.stderr?.pipe(process.stderr, { end: false });
+}
+
+async function startDevServices(): Promise<string> {
+  mkdirSync(LOGS_DIR, { recursive: true });
+  const apiPort = await findFreePort();
+  const webPort = await findFreePort();
+
+  const baseEnv = { ...process.env, FORCE_COLOR: "1" };
+
+  // Spawn each child as its own process group so we can take down any
+  // grandchildren (pnpm → node → tsx → server) on Electron exit with a
+  // single signal.
+  const detached = process.platform !== "win32";
+
+  devServerProc = spawn(
+    "pnpm",
+    ["--filter", "@github-dashboard/server", "dev"],
+    {
+      cwd: REPO_ROOT,
+      env: { ...baseEnv, PORT: String(apiPort) },
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
+      detached,
+    },
+  );
+  tee(devServerProc, "server.log");
+
+  devWebProc = spawn("pnpm", ["--filter", "@github-dashboard/web", "dev"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...baseEnv,
+      GHD_API_PORT: String(apiPort),
+      GHD_WEB_PORT: String(webPort),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+    detached,
+  });
+  tee(devWebProc, "web.log");
+
+  const webUrl = `http://localhost:${webPort}`;
+  // Stable discovery file for tooling (Playwright MCP, etc.) so it can find
+  // the current dev URL without hardcoding ports.
+  writeFileSync(
+    path.join(LOGS_DIR, "ports.json"),
+    `${JSON.stringify({ api: apiPort, web: webPort, url: webUrl }, null, 2)}\n`,
+  );
+
+  await waitForUrl(webUrl);
+  return webUrl;
+}
+
+function killGroup(proc: ChildProcess | null): void {
+  if (!proc?.pid) return;
+  try {
+    if (process.platform === "win32") {
+      proc.kill();
+    } else {
+      // Negative pid signals the whole process group (set up via `detached`),
+      // which catches pnpm's intermediate node processes too.
+      process.kill(-proc.pid, "SIGTERM");
+    }
+  } catch {
+    // Already exited.
+  }
+}
+
+function stopDevServices(): void {
+  killGroup(devServerProc);
+  devServerProc = null;
+  killGroup(devWebProc);
+  devWebProc = null;
+}
+
+async function waitForUrl(url: string): Promise<void> {
+  const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url);
-      if (res.ok || res.status === 500) return;
+      if (res.status < 500) return;
     } catch {
-      // ignore — server still booting
+      // ignore — service still booting
     }
-    await new Promise((r) => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r, 200));
   }
-  throw new Error("Embedded server failed to start within 10s");
+  throw new Error(`Dev service at ${url} failed to start within 30s`);
 }
 
 async function createWindow(): Promise<void> {
@@ -86,8 +172,8 @@ async function createWindow(): Promise<void> {
     await startEmbeddedServer();
     await mainWindow.loadURL(`http://localhost:${serverPort}/`);
   } else {
-    // Dev: assumes `pnpm dev` is running concurrently (Vite on 7200, Hono on 7100).
-    await mainWindow.loadURL(DEV_WEB_URL);
+    const devUrl = await startDevServices();
+    await mainWindow.loadURL(devUrl);
     mainWindow.webContents.openDevTools({ mode: "detach" });
   }
 }
@@ -215,6 +301,10 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     setupAutoUpdater();
   }
+});
+
+app.on("will-quit", () => {
+  stopDevServices();
 });
 
 app.on("window-all-closed", () => {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -11,9 +11,10 @@ export default defineConfig({
     },
   },
   server: {
-    port: 7200,
+    port: Number(process.env.GHD_WEB_PORT) || 7200,
+    strictPort: process.env.GHD_WEB_PORT != null,
     proxy: {
-      "/api": "http://localhost:7100",
+      "/api": `http://localhost:${process.env.GHD_API_PORT ?? 7100}`,
     },
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260420.1
         version: 7.0.0-dev.20260420.1
-      concurrently:
-        specifier: ^9.1.2
-        version: 9.2.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -26,9 +23,6 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
-      wait-on:
-        specifier: ^8.0.1
-        version: 8.0.5
 
   packages/desktop:
     dependencies:
@@ -775,26 +769,6 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-
-  '@hapi/address@5.1.1':
-    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/formula@3.0.2':
-    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
-
-  '@hapi/hoek@11.0.7':
-    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
-
-  '@hapi/pinpoint@2.0.1':
-    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
-
-  '@hapi/tlds@1.1.6':
-    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
-    engines: {node: '>=14.0.0'}
-
-  '@hapi/topo@6.0.2':
-    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -1819,9 +1793,6 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
-
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -2066,11 +2037,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  concurrently@9.2.1:
-    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   config-file-ts@0.2.8-rc1:
     resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
@@ -2507,15 +2473,6 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
-
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2974,10 +2931,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  joi@18.2.1:
-    resolution: {integrity: sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==}
-    engines: {node: '>= 20'}
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
@@ -3779,10 +3732,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3968,9 +3917,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -4040,10 +3986,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -4201,10 +4143,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4287,10 +4225,6 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
-
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4544,11 +4478,6 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
-
-  wait-on@8.0.5:
-    resolution: {integrity: sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -5223,22 +5152,6 @@ snapshots:
   '@fontsource-variable/inter@5.2.8': {}
 
   '@gar/promisify@1.1.3': {}
-
-  '@hapi/address@5.1.1':
-    dependencies:
-      '@hapi/hoek': 11.0.7
-
-  '@hapi/formula@3.0.2': {}
-
-  '@hapi/hoek@11.0.7': {}
-
-  '@hapi/pinpoint@2.0.1': {}
-
-  '@hapi/tlds@1.1.6': {}
-
-  '@hapi/topo@6.0.2':
-    dependencies:
-      '@hapi/hoek': 11.0.7
 
   '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:
@@ -6188,16 +6101,6 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios@1.16.1:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -6474,15 +6377,6 @@ snapshots:
       readable-stream: 3.6.2
 
   concat-map@0.0.1: {}
-
-  concurrently@9.2.1:
-    dependencies:
-      chalk: 4.1.2
-      rxjs: 7.8.2
-      shell-quote: 1.8.3
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
 
   config-file-ts@0.2.8-rc1:
     dependencies:
@@ -7027,8 +6921,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.16.0: {}
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7527,16 +7419,6 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.6.1: {}
-
-  joi@18.2.1:
-    dependencies:
-      '@hapi/address': 5.1.1
-      '@hapi/formula': 3.0.2
-      '@hapi/hoek': 11.0.7
-      '@hapi/pinpoint': 2.0.1
-      '@hapi/tlds': 1.1.6
-      '@hapi/topo': 6.0.2
-      '@standard-schema/spec': 1.1.0
 
   jose@6.2.2: {}
 
@@ -8521,8 +8403,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@2.1.0: {}
-
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -8778,10 +8658,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
-
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -8891,8 +8767,6 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  shell-quote@1.8.3: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -9060,10 +8934,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-color@8.1.1:
-    dependencies:
-      has-flag: 4.0.0
-
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
@@ -9138,8 +9008,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-
-  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -9360,17 +9228,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  wait-on@8.0.5:
-    dependencies:
-      axios: 1.16.1
-      joi: 18.2.1
-      lodash: 4.18.1
-      minimist: 1.2.8
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   wcwidth@1.0.1:
     dependencies:


### PR DESCRIPTION
Closes #54.

## Summary

`pnpm dev` now builds the Electron main and launches it as the sole entry point. In dev mode, Electron picks two free ports, spawns the server and Vite as children with the right env vars, waits for Vite, then loads the dev URL.

- Server child gets `PORT=<api>`
- Vite child gets `GHD_API_PORT=<api>` and `GHD_WEB_PORT=<web>`; `vite.config.ts` reads both (proxy target + dev server port, with `strictPort` when orchestrated)
- Children are spawned as detached process groups; `will-quit` sends `SIGTERM` to the whole pnpm → node → tsx tree
- `.logs/ports.json` is written on startup with `{ api, web, url }` so tooling (Playwright MCP, etc.) can discover the current dev URL without hardcoding

## Consequences

- Concurrent `pnpm dev` sessions no longer collide on 7100/7200 — each gets a fresh pair.
- The non-Electron browser dev workflow (`pnpm dev` → Chrome at `localhost:7200`) goes away; the desktop app is the dev surface. `pnpm --filter @github-dashboard/web dev` still works standalone — when `GHD_API_PORT` is unset the proxy falls back to 7100.
- `dev:desktop` and `demo:desktop` scripts collapse into `dev` / `demo`. `concurrently` and `wait-on` are no longer needed and have been removed.
- `AGENTS.md` updated: read `.logs/ports.json` to find the current dev URL.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check`, `pnpm test` pass
- [x] `pnpm dev` boots: `.logs/ports.json` lists fresh random ports each run, `curl <web>/` returns 200, `curl <web>/api/instances` (proxied) returns 200, server reachable directly on `<api>`
- [ ] Spot-check on macOS: two concurrent `pnpm dev` sessions both come up cleanly, no `EADDRINUSE`
- [ ] Quitting the Electron window terminates the spawned server + Vite (no orphans)


---
_Generated by [Claude Code](https://claude.ai/code/session_0156JYEJ484FwrQcXegamAgZ)_