### PR TITLE
server: fall back to direct merge when auto-merge hits "clean status"

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -287,6 +287,41 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/auto-merge", async (c) => {
       if (/auto.?merge is not allowed/i.test(msg)) {
         return c.json({ error: "auto_merge_not_allowed" }, 422);
       }
+      // PR is already mergeable — GitHub refuses to queue auto-merge.
+      // Fall through to a direct squash merge to match user intent.
+      if (/clean status/i.test(msg)) {
+        const fullRepo = `${owner}/${repo}`;
+        try {
+          await client.pulls.merge({
+            owner,
+            repo,
+            pull_number: num,
+            merge_method: "squash",
+          });
+        } catch (mergeErr) {
+          const e = mergeErr as { response?: { data?: { message?: string } } };
+          const raw = e.response?.data?.message;
+          const message = raw
+            ? raw
+                .split("\n")
+                .map((l) => l.trim())
+                .filter((l) => l.length > 0)
+                .join(" — ")
+            : "Failed to merge PR";
+          return c.json({ error: "merge_rejected", message }, 422);
+        }
+
+        patchCache(`${instanceId}:prs`, removeFromList(fullRepo, num));
+        patchCache(`${instanceId}:reviews`, removeFromList(fullRepo, num));
+        recordMutation(instanceId, {
+          kind: "removed",
+          repo: fullRepo,
+          number: num,
+        });
+        scheduleResync(instanceId, ["prs", "reviews", "recent-prs"]);
+
+        return c.json({ ok: true, merged: true });
+      }
       throw err;
     }
   }


### PR DESCRIPTION
## Summary

When toggling auto-merge on a PR that's already in a mergeable state, GitHub's `enablePullRequestAutoMerge` mutation refuses to enqueue because there's nothing to wait on. Today that surfaces as a 500 in the dashboard. This change catches that specific error and falls through to a direct squash merge, matching the user's intent ("merge this").

## Error response from server logs

Captured while clicking auto-merge on a PR that had already gone green:

```
GraphqlResponseError: Request failed due to following response errors:
 - Pull request Pull request is in clean status
    at .../packages/server/src/routes.ts:281:7
  errors: [
    {
      type: 'UNPROCESSABLE',
      path: [Array],
      locations: [Array],
      message: 'Pull request Pull request is in clean status'
    }
  ],
  data: { enablePullRequestAutoMerge: null },
  request: {
    query: 'mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { id } } }',
    variables: { id: 'PR_kwDOR3u_wM7dZnTn' }
  }
```

The existing handler only caught `/auto.?merge is not allowed/i`, so this `clean status` variant bubbled up unhandled.

## Behavior

- Auto-merge enable on a not-yet-mergeable PR: unchanged.
- Auto-merge enable on an already-mergeable PR: now does a squash merge instead of erroring. Response is `{ ok: true, merged: true }`.
- `merge_rejected` errors from the fallback merge are surfaced the same way the dedicated `/merge` endpoint does.

## Test plan

- [ ] Click auto-merge on a PR with pending required checks → auto-merge enqueued as before.
- [ ] Click auto-merge on a PR that's already green → PR is merged in one click; row disappears from the list.
- [ ] Click auto-merge on a green PR with a branch-protection violation (e.g. unresolved conversation) → toast shows the actionable reason, no 500.