### PR TITLE
Revert v0.0.2 bump (release torn down)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@github-dashboard/desktop",
   "productName": "GitHub Dashboard",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "Electron desktop wrapper for github-dashboard",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Reverts the `release: desktop v0.0.2` bump commit so the next Desktop Release run lands cleanly at v0.0.2 again.
- Context: the v0.0.2 attempt aborted due to two concurrent workflow runs racing on the same draft. Fix for that race is in #60. The broken draft + tag are being deleted out-of-band.

## Test plan

- [ ] After merging #60 + this, trigger Desktop Release (mode=release) and confirm the new tag is `v0.0.2` again.