### PR TITLE
release-notes: trim bot, group by author

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,3 @@
+changelog:
+  exclude:
+    authors: [github-actions]


### PR DESCRIPTION
## Summary

- Adds `.github/release.yml` so GitHub's auto-generated notes exclude the `github-actions` bot (cheap insurance — the version-bump commit isn't a PR today, but future bot PRs won't leak in).
- Adds `.github/scripts/group-changelog.mjs` + wires it into the desktop-release workflow's "Write release notes" step. It buckets the "What's Changed" bullets under one `### @author` heading per contributor and shortens PR refs from full URLs to `(#NUM)`. Trades 8× repeated `by @AntonNiklasson` for a single heading.

## Sample output (run against v0.0.2's current notes)

````
## What's Changed
### @AntonNiklasson
- desktop-release: surface .dmg links + auto-changelog in notes (#45)
- Filter auto-routed review requests (CODEOWNERS-style) (#44)
- reviews: classify the current attachment, not historical events (#48)
- ...

### @kewah
- readme: link to pre-filled PAT creation page (#52)
````

## Test plan

- [ ] Next desktop release run — confirm the published notes are grouped by author and PR refs render as auto-linked `#NUM`.
- [ ] Optional: after merge, regenerate v0.0.2 notes retroactively.