### PR TITLE
drop recently-closed PRs

### DIFF
--- a/packages/server/src/fetchers.integration.test.ts
+++ b/packages/server/src/fetchers.integration.test.ts
@@ -37,13 +37,8 @@ vi.mock("./cache.js", () => ({
   },
 }));
 
-const {
-  fetchPrs,
-  fetchNotifications,
-  fetchRecentPrs,
-  fetchReviews,
-  notificationHtmlUrl,
-} = await import("./fetchers.js");
+const { fetchPrs, fetchNotifications, fetchReviews, notificationHtmlUrl } =
+  await import("./fetchers.js");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -214,19 +209,6 @@ describe("fetchPrs", () => {
     });
     const prs = await fetchPrs("github");
     expect(prs[0].autoMergeAllowed).toBe(false);
-  });
-});
-
-describe("fetchRecentPrs", () => {
-  it("queries closed PRs from the last week", async () => {
-    mockOctokit.search.issuesAndPullRequests.mockResolvedValue({
-      data: { items: [] },
-    });
-    await fetchRecentPrs("github");
-    const q = mockOctokit.search.issuesAndPullRequests.mock.calls[0][0].q;
-    expect(q).toContain("author:alice");
-    expect(q).toContain("state:closed");
-    expect(q).toMatch(/closed:>=\d{4}-\d{2}-\d{2}/);
   });
 });
 

--- a/packages/server/src/fetchers.ts
+++ b/packages/server/src/fetchers.ts
@@ -257,54 +257,6 @@ export async function fetchPrs(instanceId: string) {
   return prs.filter((pr) => pr.author === username);
 }
 
-export async function fetchRecentPrs(instanceId: string) {
-  const client = await getClient(instanceId);
-  const { username } = await getInstance(instanceId);
-
-  const today = new Date();
-  const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .slice(0, 10);
-
-  const { data } = await client.search.issuesAndPullRequests({
-    q: `author:${username} type:pr state:closed closed:>=${weekAgo}`,
-    sort: "updated",
-    order: "desc",
-    per_page: 20,
-  });
-
-  // Fetch detailed PR data for each result
-  const prs = await Promise.all(
-    data.items.map(async (item) => {
-      const [owner, repo] = item.repository_url.split("/").slice(-2);
-      const prNumber = item.number;
-
-      const prRes = await client.pulls
-        .get({ owner, repo, pull_number: prNumber })
-        .catch(() => null);
-
-      const prData = prRes?.data;
-
-      return {
-        id: item.id,
-        number: item.number,
-        title: item.title,
-        url: item.html_url,
-        repo: `${owner}/${repo}`,
-        createdAt: item.created_at,
-        updatedAt: item.updated_at,
-        merged: item.pull_request?.merged_at != null,
-        headBranch: prData?.head.ref ?? "",
-        additions: prData?.additions ?? 0,
-        deletions: prData?.deletions ?? 0,
-        commits: prData?.commits ?? 0,
-      };
-    }),
-  );
-
-  return prs;
-}
-
 export async function fetchReviews(instanceId: string) {
   const client = await getClient(instanceId);
   const { username } = await getInstance(instanceId);

--- a/packages/server/src/routes.test.ts
+++ b/packages/server/src/routes.test.ts
@@ -13,7 +13,6 @@ const { cacheStore, configStub, fetchersStub, mockOctokit, octokitHolder } =
       },
       fetchersStub: {
         fetchPrs: vi.fn(),
-        fetchRecentPrs: vi.fn(),
         fetchReviews: vi.fn(),
         fetchNotifications: vi.fn(),
         latestCheckRunsByName: <T extends { name: string }>(runs: T[]): T[] => {
@@ -337,11 +336,10 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/auto-merge", () => {
 });
 
 describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
-  it("merges with squash and resyncs prs, reviews, recent-prs", async () => {
+  it("merges with squash and resyncs prs, reviews", async () => {
     mockOctokit.pulls.merge.mockResolvedValue({});
     fetchersStub.fetchPrs.mockResolvedValue([]);
     fetchersStub.fetchReviews.mockResolvedValue([]);
-    fetchersStub.fetchRecentPrs.mockResolvedValue([]);
     const res = await call("/github/prs/o/r/5/merge", { method: "POST" });
     expect(res.status).toBe(200);
     expect(mockOctokit.pulls.merge).toHaveBeenCalledWith({
@@ -353,7 +351,6 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
     await waitForPendingResyncs();
     expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
     expect(fetchersStub.fetchReviews).toHaveBeenCalledWith("github");
-    expect(fetchersStub.fetchRecentPrs).toHaveBeenCalledWith("github");
   });
 
   it("forwards GitHub's full error message (joining non-empty lines) when merge is rejected", async () => {
@@ -385,7 +382,6 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
       { id: 11, repo: "o/r", number: 5, title: "x" },
       { id: 12, repo: "o/r", number: 7, title: "other" },
     ]);
-    cacheStore.set("github:recent-prs", []);
     mockOctokit.pulls.merge.mockResolvedValue({});
 
     // Simulate GitHub eventual consistency: search index still returns the PR.
@@ -397,7 +393,6 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
       { id: 11, repo: "o/r", number: 5, title: "x" },
       { id: 12, repo: "o/r", number: 7, title: "other" },
     ]);
-    fetchersStub.fetchRecentPrs.mockResolvedValue([]);
 
     const res = await call("/github/prs/o/r/5/merge", { method: "POST" });
     expect(res.status).toBe(200);
@@ -413,12 +408,11 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/merge", () => {
 });
 
 describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
-  it("sets state=closed and resyncs prs, reviews, recent-prs", async () => {
+  it("sets state=closed and resyncs prs, reviews", async () => {
     cacheStore.set("github:prs", [{ id: 1 }]);
     cacheStore.set("github:reviews", [{ id: 2 }]);
     fetchersStub.fetchPrs.mockResolvedValue([]);
     fetchersStub.fetchReviews.mockResolvedValue([]);
-    fetchersStub.fetchRecentPrs.mockResolvedValue([{ id: 5, state: "closed" }]);
     mockOctokit.pulls.update.mockResolvedValue({});
     const res = await call("/github/prs/o/r/5/close", { method: "POST" });
     expect(res.status).toBe(200);
@@ -431,7 +425,6 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
     await waitForPendingResyncs();
     expect(fetchersStub.fetchPrs).toHaveBeenCalledWith("github");
     expect(fetchersStub.fetchReviews).toHaveBeenCalledWith("github");
-    expect(fetchersStub.fetchRecentPrs).toHaveBeenCalledWith("github");
   });
 
   it("removes the closed PR from cached prs/reviews even when GitHub still reports it as open", async () => {
@@ -442,7 +435,6 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
     cacheStore.set("github:reviews", [
       { id: 11, repo: "o/r", number: 5, title: "x" },
     ]);
-    cacheStore.set("github:recent-prs", []);
     mockOctokit.pulls.update.mockResolvedValue({});
 
     fetchersStub.fetchPrs.mockResolvedValue([
@@ -452,7 +444,6 @@ describe("POST /:instanceId/prs/:owner/:repo/:prNumber/close", () => {
     fetchersStub.fetchReviews.mockResolvedValue([
       { id: 11, repo: "o/r", number: 5, title: "x" },
     ]);
-    fetchersStub.fetchRecentPrs.mockResolvedValue([]);
 
     const res = await call("/github/prs/o/r/5/close", { method: "POST" });
     expect(res.status).toBe(200);

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -12,7 +12,6 @@ import {
 import {
   fetchNotifications,
   fetchPrs,
-  fetchRecentPrs,
   fetchReviews,
   latestCheckRunsByName,
 } from "./fetchers.js";
@@ -183,18 +182,6 @@ api.get("/:instanceId/prs", async (c) => {
   return c.json(data);
 });
 
-// Recently closed/merged PRs (today)
-api.get("/:instanceId/recent-prs", async (c) => {
-  const { instanceId } = c.req.param();
-  const fresh = c.req.query("fresh") === "1";
-  const data = await cachedOrFetch(
-    `${instanceId}:recent-prs`,
-    () => fetchRecentPrs(instanceId),
-    fresh,
-  );
-  return c.json(data);
-});
-
 // PRs awaiting my review
 api.get("/:instanceId/reviews", async (c) => {
   const { instanceId } = c.req.param();
@@ -330,7 +317,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/merge", async (c) => {
   patchCache(`${instanceId}:prs`, removeFromList(fullRepo, num));
   patchCache(`${instanceId}:reviews`, removeFromList(fullRepo, num));
   recordMutation(instanceId, { kind: "removed", repo: fullRepo, number: num });
-  scheduleResync(instanceId, ["prs", "reviews", "recent-prs"]);
+  scheduleResync(instanceId, ["prs", "reviews"]);
 
   return c.json({ ok: true });
 });
@@ -352,7 +339,7 @@ api.post("/:instanceId/prs/:owner/:repo/:prNumber/close", async (c) => {
   patchCache(`${instanceId}:prs`, removeFromList(fullRepo, num));
   patchCache(`${instanceId}:reviews`, removeFromList(fullRepo, num));
   recordMutation(instanceId, { kind: "removed", repo: fullRepo, number: num });
-  scheduleResync(instanceId, ["prs", "reviews", "recent-prs"]);
+  scheduleResync(instanceId, ["prs", "reviews"]);
 
   return c.json({ ok: true });
 });

--- a/packages/server/src/sync.ts
+++ b/packages/server/src/sync.ts
@@ -1,27 +1,21 @@
 import { setCached } from "./cache.js";
 import { getInstances } from "./config.js";
-import {
-  fetchNotifications,
-  fetchPrs,
-  fetchRecentPrs,
-  fetchReviews,
-} from "./fetchers.js";
+import { fetchNotifications, fetchPrs, fetchReviews } from "./fetchers.js";
 
 const SYNC_INTERVAL = 30_000; // 30s
 
-export type ResyncKey = "prs" | "recent-prs" | "reviews" | "notifications";
+export type ResyncKey = "prs" | "reviews" | "notifications";
 
 const RESYNC_FETCHERS: Record<
   ResyncKey,
   (instanceId: string) => Promise<unknown>
 > = {
   prs: fetchPrs,
-  "recent-prs": fetchRecentPrs,
   reviews: fetchReviews,
   notifications: fetchNotifications,
 };
 
-const ALL_KEYS: ResyncKey[] = ["prs", "recent-prs", "reviews", "notifications"];
+const ALL_KEYS: ResyncKey[] = ["prs", "reviews", "notifications"];
 
 const pending = new Set<Promise<unknown>>();
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -460,7 +460,7 @@ function getActionsForItem(
       onSelect: () => {
         const base = item.url.replace(/\/pull\/\d+.*$/, "");
         window.open(
-          `${base}/pulls?q=author%3A${item.author}+is%3Aopen+sort%3Aupdated-desc`,
+          `${base}/pulls?q=author%3A${item.author}+sort%3Aupdated-desc`,
           "_blank",
         );
       },

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -49,24 +49,16 @@ import {
   type Section,
   useAllAuthoredPrs,
   useAllNotifications,
-  useAllRecentPrs,
   useAllReviewRequests,
   useAuthoredPrs,
   useColleaguePrs,
   useInstances,
   useKeyboardNav,
   useNotifications,
-  useRecentPrs,
   useReviewRequests,
 } from "./hooks";
 import { getInstanceColor } from "./instance-colors";
-import type {
-  Instance,
-  Notification,
-  PR,
-  RecentPR,
-  ReviewRequest,
-} from "./types";
+import type { Instance, Notification, PR, ReviewRequest } from "./types";
 import { applyTheme, themeAtom } from "./theme";
 import * as mutations from "./mutations";
 
@@ -398,8 +390,6 @@ function confirmAndMerge(
       instanceId: item.instanceId,
       repo: item.repo,
       number: item.number,
-      title: item.title,
-      url: item.url,
     })
     .catch(() => {});
 }
@@ -572,8 +562,6 @@ function getActionsForItem(
             instanceId: item.instanceId!,
             repo: item.repo!,
             number: item.number!,
-            title: item.title,
-            url: item.url,
           })
           .catch(() => {});
       },
@@ -591,7 +579,6 @@ interface DashboardSource {
     isFetching: boolean;
     error: Error | null;
   };
-  recentPrs: { data: RecentPR[] };
   reviews: {
     data: ReviewRequest[];
     isLoading: boolean;
@@ -608,7 +595,6 @@ interface DashboardSource {
 
 function MultiInstanceDashboard({ instances }: { instances: Instance[] }) {
   const prs = useAllAuthoredPrs(instances);
-  const recentPrs = useAllRecentPrs(instances);
   const reviews = useAllReviewRequests(instances);
   const notifications = useAllNotifications(instances);
   const source: DashboardSource = {
@@ -619,7 +605,6 @@ function MultiInstanceDashboard({ instances }: { instances: Instance[] }) {
       isFetching: prs.isFetching,
       error: prs.error as Error | null,
     },
-    recentPrs: { data: recentPrs.data },
     reviews: {
       data: reviews.data,
       isLoading: reviews.isLoading,
@@ -646,7 +631,6 @@ function SingleInstanceDashboard({
   const prs = authorFilter
     ? useColleaguePrs(instance.id, authorFilter)
     : useAuthoredPrs(instance.id);
-  const recentPrs = useRecentPrs(instance.id);
   const reviews = useReviewRequests(instance.id);
   const notifications = useNotifications(instance.id);
   const source: DashboardSource = {
@@ -657,7 +641,6 @@ function SingleInstanceDashboard({
       isFetching: prs.isFetching,
       error: (prs.error as Error | null) ?? null,
     },
-    recentPrs: { data: recentPrs.data ?? [] },
     reviews: {
       data: reviews.data ?? [],
       isLoading: reviews.isLoading,
@@ -676,7 +659,7 @@ function SingleInstanceDashboard({
 
 function Dashboard({ source }: { source: DashboardSource }) {
   const queryClient = useQueryClient();
-  const { instances, prs, recentPrs, reviews, notifications } = source;
+  const { instances, prs, reviews, notifications } = source;
   const [dismissed, setDismissed] = useAtom(dismissedReviewsAtom);
   const [showCodeOwnerRequests, setShowCodeOwnerRequests] = useAtom(
     showCodeOwnerRequestsAtom,
@@ -709,7 +692,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
 
   const sections: Section[] = ["prs", "reviews", "notifications"];
   const itemCounts = {
-    prs: sortedPrs.length + recentPrs.data.length,
+    prs: sortedPrs.length,
     reviews: filteredReviews.length,
     notifications: sortedNotifications.length,
   };
@@ -790,13 +773,11 @@ function Dashboard({ source }: { source: DashboardSource }) {
 
   const navRef = useRef(nav);
   const prsRef = useRef(sortedPrs);
-  const recentPrsRef = useRef(recentPrs.data);
   const reviewsRef = useRef(filteredReviews);
   const notificationsRef = useRef(sortedNotifications);
   const instancesRef = useRef(instances);
   navRef.current = nav;
   prsRef.current = sortedPrs;
-  recentPrsRef.current = recentPrs.data;
   reviewsRef.current = filteredReviews;
   notificationsRef.current = sortedNotifications;
   instancesRef.current = instances;
@@ -806,7 +787,6 @@ function Dashboard({ source }: { source: DashboardSource }) {
       navRef.current.activeSection,
       navRef.current.focusIndex,
       prsRef.current,
-      recentPrsRef.current,
       reviewsRef.current,
       notificationsRef.current,
       instancesRef.current,
@@ -815,7 +795,7 @@ function Dashboard({ source }: { source: DashboardSource }) {
     Math.max(
       0,
       ({
-        prs: prsRef.current.length + recentPrsRef.current.length,
+        prs: prsRef.current.length,
         reviews: reviewsRef.current.length,
         notifications: notificationsRef.current.length,
       }[navRef.current.activeSection] ?? 0) - 1,
@@ -958,8 +938,6 @@ function Dashboard({ source }: { source: DashboardSource }) {
               instanceId: item.instanceId,
               repo: item.repo,
               number: item.number,
-              title: item.title,
-              url: item.url,
             })
             .catch(() => {});
         }
@@ -1090,7 +1068,6 @@ function Dashboard({ source }: { source: DashboardSource }) {
             focusIndex={nav.focusIndex}
             isFocusedSection={nav.activeSection === "prs"}
             togglingDraftId={togglingDraftId ?? undefined}
-            recentPrs={recentPrs.data}
             editingPrNumber={editingPrNumber ?? undefined}
             onSaveTitle={async (prNumber, title) => {
               const pr = sortedPrs.find((p) => p.number === prNumber);
@@ -1285,7 +1262,6 @@ function getFocusedItem(
   section: Section,
   idx: number,
   prs: PR[],
-  recentPrs: RecentPR[],
   reviews: ReviewRequest[],
   notifications: Notification[],
   instances: Instance[],
@@ -1315,24 +1291,6 @@ function getFocusedItem(
       baseBranch: p.baseBranch,
       commentCount: p.commentCount,
       ciStatus: p.ciStatus,
-    };
-  }
-  if (section === "prs" && recentPrs[idx - prs.length]) {
-    const p = recentPrs[idx - prs.length];
-    const inst =
-      instances.find((i) => i.label === p.instanceLabel) ?? instances[0];
-    return {
-      url: p.url,
-      title: p.title,
-      section,
-      repo: p.repo,
-      number: p.number,
-      instanceId: inst?.id,
-      additions: p.additions,
-      deletions: p.deletions,
-      reviews: { approved: [], changesRequested: [] },
-      headBranch: p.headBranch,
-      readOnly: true,
     };
   }
   if (section === "reviews" && reviews[idx]) {

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -2,7 +2,6 @@ import type {
   Instance,
   Notification,
   PR,
-  RecentPR,
   ReviewRequest,
   SearchPR,
 } from "./types";
@@ -62,10 +61,6 @@ export const api = {
   instances: () => fetchJson<Instance[]>("/api/instances"),
   prs: (instanceId: string, fresh = false) =>
     fetchJson<PR[]>(`/api/${instanceId}/prs${fresh ? "?fresh=1" : ""}`),
-  recentPrs: (instanceId: string, fresh = false) =>
-    fetchJson<RecentPR[]>(
-      `/api/${instanceId}/recent-prs${fresh ? "?fresh=1" : ""}`,
-    ),
   reviews: (instanceId: string, fresh = false) =>
     fetchJson<ReviewRequest[]>(
       `/api/${instanceId}/reviews${fresh ? "?fresh=1" : ""}`,

--- a/packages/web/src/components/PrList.tsx
+++ b/packages/web/src/components/PrList.tsx
@@ -1,4 +1,4 @@
-import type { PR, RecentPR } from "../types";
+import type { PR } from "../types";
 import { FocusLi } from "./FocusLi";
 import { PrCard } from "./PrCard";
 import { toMergeStatus } from "./PrStateIcon";
@@ -9,7 +9,6 @@ interface Props {
   focusIndex: number;
   isFocusedSection: boolean;
   togglingDraftId?: number;
-  recentPrs?: RecentPR[];
   editingPrNumber?: number;
   onSaveTitle?: (prNumber: number, title: string) => void;
 }
@@ -19,11 +18,10 @@ export function PrList({
   focusIndex,
   isFocusedSection,
   togglingDraftId,
-  recentPrs,
   editingPrNumber,
   onSaveTitle,
 }: Props) {
-  if (prs.length === 0 && (!recentPrs || recentPrs.length === 0)) {
+  if (prs.length === 0) {
     return (
       <p className="py-4 text-center text-muted-foreground">
         <Text>No open PRs</Text>
@@ -31,90 +29,44 @@ export function PrList({
     );
   }
 
-  const recentOffset = prs.length;
-
   return (
-    <div>
-      <ul className="space-y-2">
-        {prs.map((pr, i) => {
-          const focused = isFocusedSection && focusIndex === i;
-          return (
-            <FocusLi key={pr.id} focused={focused}>
-              <PrCard
-                title={pr.title}
-                url={pr.url}
-                repo={pr.repo}
-                number={pr.number}
-                createdAt={pr.createdAt}
-                updatedAt={pr.updatedAt}
-                author={pr.author}
-                authorAvatar={pr.authorAvatar}
-                mergeStatus={toMergeStatus(pr)}
-                loading={togglingDraftId === pr.id}
-                ciStatus={pr.ciStatus}
-                autoMerge={pr.autoMerge}
-                headBranch={pr.headBranch}
-                baseBranch={pr.baseBranch}
-                reviews={pr.reviews}
-                reviewDecision={pr.reviewDecision}
-                additions={pr.additions}
-                deletions={pr.deletions}
-                commits={pr.commits}
-                commentCount={pr.commentCount}
-                conflict={pr.mergeable === false}
-                unresolvedThreadCount={pr.unresolvedThreadCount}
-                focused={focused}
-                instanceId={pr.instanceId}
-                instanceLabel={pr.instanceLabel}
-                editing={editingPrNumber === pr.number}
-                onSaveTitle={(title) => onSaveTitle?.(pr.number, title)}
-              />
-            </FocusLi>
-          );
-        })}
-      </ul>
-
-      {recentPrs && recentPrs.length > 0 && (
-        <>
-          <div className="mt-12 mb-3 flex items-center gap-2 text-muted-foreground">
-            <div className="h-px flex-1 bg-border" />
-            <Text size="small">Last 7 days</Text>
-            <div className="h-px flex-1 bg-border" />
-          </div>
-          <ul className="space-y-2">
-            {recentPrs.map((pr, i) => {
-              const focused =
-                isFocusedSection && focusIndex === recentOffset + i;
-              return (
-                <FocusLi key={pr.id} focused={focused}>
-                  <PrCard
-                    title={pr.title}
-                    url={pr.url}
-                    repo={pr.repo}
-                    number={pr.number}
-                    updatedAt={pr.updatedAt}
-                    mergeStatus={pr.merged ? "merged" : "closed"}
-                    ciStatus="unknown"
-                    autoMerge={false}
-                    headBranch={pr.headBranch ?? ""}
-                    baseBranch=""
-                    reviews={{ approved: [], changesRequested: [] }}
-                    additions={pr.additions ?? 0}
-                    deletions={pr.deletions ?? 0}
-                    commits={pr.commits ?? 0}
-                    commentCount={0}
-                    focused={focused}
-                    instanceId={pr.instanceId}
-                    instanceLabel={pr.instanceLabel}
-                    editing={editingPrNumber === pr.number}
-                    onSaveTitle={(title) => onSaveTitle?.(pr.number, title)}
-                  />
-                </FocusLi>
-              );
-            })}
-          </ul>
-        </>
-      )}
-    </div>
+    <ul className="space-y-2">
+      {prs.map((pr, i) => {
+        const focused = isFocusedSection && focusIndex === i;
+        return (
+          <FocusLi key={pr.id} focused={focused}>
+            <PrCard
+              title={pr.title}
+              url={pr.url}
+              repo={pr.repo}
+              number={pr.number}
+              createdAt={pr.createdAt}
+              updatedAt={pr.updatedAt}
+              author={pr.author}
+              authorAvatar={pr.authorAvatar}
+              mergeStatus={toMergeStatus(pr)}
+              loading={togglingDraftId === pr.id}
+              ciStatus={pr.ciStatus}
+              autoMerge={pr.autoMerge}
+              headBranch={pr.headBranch}
+              baseBranch={pr.baseBranch}
+              reviews={pr.reviews}
+              reviewDecision={pr.reviewDecision}
+              additions={pr.additions}
+              deletions={pr.deletions}
+              commits={pr.commits}
+              commentCount={pr.commentCount}
+              conflict={pr.mergeable === false}
+              unresolvedThreadCount={pr.unresolvedThreadCount}
+              focused={focused}
+              instanceId={pr.instanceId}
+              instanceLabel={pr.instanceLabel}
+              editing={editingPrNumber === pr.number}
+              onSaveTitle={(title) => onSaveTitle?.(pr.number, title)}
+            />
+          </FocusLi>
+        );
+      })}
+    </ul>
   );
 }

--- a/packages/web/src/hooks.ts
+++ b/packages/web/src/hooks.ts
@@ -1,13 +1,7 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "./api";
-import type {
-  Instance,
-  Notification,
-  PR,
-  RecentPR,
-  ReviewRequest,
-} from "./types";
+import type { Instance, Notification, PR, ReviewRequest } from "./types";
 
 const POLL_INTERVAL = 10_000; // 10s
 
@@ -36,20 +30,6 @@ export function useAuthoredPrs(instanceId: string) {
       const f = freshRef.current;
       freshRef.current = false;
       return api.prs(instanceId, f);
-    },
-    refetchInterval: POLL_INTERVAL,
-    enabled: !!instanceId,
-  });
-}
-
-export function useRecentPrs(instanceId: string) {
-  const freshRef = useFreshRef();
-  return useQuery({
-    queryKey: ["recent-prs", instanceId],
-    queryFn: () => {
-      const f = freshRef.current;
-      freshRef.current = false;
-      return api.recentPrs(instanceId, f);
     },
     refetchInterval: POLL_INTERVAL,
     enabled: !!instanceId,
@@ -121,36 +101,6 @@ export function useAllAuthoredPrs(instances: Instance[]) {
   const refetchAll = () => queries.forEach((q) => q.refetch());
 
   return { data, isLoading, isFetching, error, refetchAll };
-}
-
-export function useAllRecentPrs(instances: Instance[]) {
-  const freshRef = useFreshRef();
-  const queries = useQueries({
-    queries: instances.map((inst) => ({
-      queryKey: ["recent-prs", inst.id],
-      queryFn: () => {
-        const f = freshRef.current;
-        freshRef.current = false;
-        return api.recentPrs(inst.id, f);
-      },
-      refetchInterval: POLL_INTERVAL,
-    })),
-  });
-
-  const data = useMemo(() => {
-    const merged: RecentPR[] = [];
-    for (let i = 0; i < queries.length; i++) {
-      const items = queries[i].data;
-      if (!items) continue;
-      const { id, label } = instances[i];
-      for (const item of items) {
-        merged.push({ ...item, instanceId: id, instanceLabel: label });
-      }
-    }
-    return merged.sort(byUpdatedDesc);
-  }, [queries, instances]);
-
-  return { data };
 }
 
 export function useAllReviewRequests(instances: Instance[]) {

--- a/packages/web/src/mutations.ts
+++ b/packages/web/src/mutations.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { AutoMergeNotAllowedError, api } from "./api";
-import type { Notification, PR, RecentPR, ReviewRequest } from "./types";
+import type { Notification, PR, ReviewRequest } from "./types";
 
 interface Target {
   instanceId: string;
@@ -67,13 +67,9 @@ export async function toggleAutoMerge(
   }
 }
 
-export async function mergePr(
-  qc: QueryClient,
-  target: Target & { title: string; url: string },
-): Promise<void> {
+export async function mergePr(qc: QueryClient, target: Target): Promise<void> {
   const prsSnap = snapshot<PR[]>(qc, "prs");
   const reviewsSnap = snapshot<ReviewRequest[]>(qc, "reviews");
-  const recentSnap = snapshot<RecentPR[]>(qc, "recent-prs");
 
   qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
     old?.filter((pr) => !matches(target)(pr)),
@@ -81,18 +77,6 @@ export async function mergePr(
   qc.setQueriesData<ReviewRequest[]>({ queryKey: ["reviews"] }, (old) =>
     old?.filter((r) => !matches(target)(r)),
   );
-  qc.setQueriesData<RecentPR[]>({ queryKey: ["recent-prs"] }, (old) => [
-    {
-      id: Date.now(),
-      number: target.number,
-      title: target.title,
-      url: target.url,
-      repo: target.repo,
-      updatedAt: new Date().toISOString(),
-      merged: true,
-    },
-    ...(old ?? []),
-  ]);
 
   try {
     await api.mergePr(target.instanceId, target.repo, target.number);
@@ -100,7 +84,6 @@ export async function mergePr(
   } catch (err) {
     restore(qc, prsSnap);
     restore(qc, reviewsSnap);
-    restore(qc, recentSnap);
 
     // mergeStateStatus="CLEAN" can lie when repo rulesets impose extra
     // requirements GraphQL doesn't reflect. Always attempt to arm
@@ -127,13 +110,9 @@ export async function mergePr(
   }
 }
 
-export async function closePr(
-  qc: QueryClient,
-  target: Target & { title: string; url: string },
-): Promise<void> {
+export async function closePr(qc: QueryClient, target: Target): Promise<void> {
   const prsSnap = snapshot<PR[]>(qc, "prs");
   const reviewsSnap = snapshot<ReviewRequest[]>(qc, "reviews");
-  const recentSnap = snapshot<RecentPR[]>(qc, "recent-prs");
 
   qc.setQueriesData<PR[]>({ queryKey: ["prs"] }, (old) =>
     old?.filter((pr) => !matches(target)(pr)),
@@ -141,18 +120,6 @@ export async function closePr(
   qc.setQueriesData<ReviewRequest[]>({ queryKey: ["reviews"] }, (old) =>
     old?.filter((r) => !matches(target)(r)),
   );
-  qc.setQueriesData<RecentPR[]>({ queryKey: ["recent-prs"] }, (old) => [
-    {
-      id: Date.now(),
-      number: target.number,
-      title: target.title,
-      url: target.url,
-      repo: target.repo,
-      updatedAt: new Date().toISOString(),
-      merged: false,
-    },
-    ...(old ?? []),
-  ]);
 
   try {
     await api.closePr(target.instanceId, target.repo, target.number);
@@ -160,7 +127,6 @@ export async function closePr(
   } catch (err) {
     restore(qc, prsSnap);
     restore(qc, reviewsSnap);
-    restore(qc, recentSnap);
     toast.error("Failed to close PR");
     throw err;
   }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -81,22 +81,6 @@ export interface Notification {
   instanceLabel?: string;
 }
 
-export interface RecentPR {
-  id: number;
-  number: number;
-  title: string;
-  url: string;
-  repo: string;
-  updatedAt: string;
-  merged: boolean;
-  headBranch?: string;
-  additions?: number;
-  deletions?: number;
-  commits?: number;
-  instanceId?: string;
-  instanceLabel?: string;
-}
-
 export interface SearchPR {
   id: number;
   number: number;


### PR DESCRIPTION
## Summary

- Removes the "Last 7 days" section under My work end-to-end:
  - server: `/api/{instanceId}/recent-prs` route, `fetchRecentPrs`, the `"recent-prs"` ResyncKey, the sync/cache wiring.
  - web: `useRecentPrs` / `useAllRecentPrs`, `RecentPR` type, `PrList`'s `recentPrs` slot, the App.tsx wiring + focus indices.
  - mutations: `mergePr` / `closePr` no longer need an optimistic insertion into the recent list — `target` collapses to plain `Target`.
- Closed-PR data was low-signal and REST-heavy (per-PR `pulls.get` on every poll). Net: -289 LOC and one fewer REST call per closed PR per cycle.

Prerequisite cleanup before the wider per-PR fetching refactor.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 124 server + 39 web tests pass
- [x] Smoke test in browser: dashboard renders, no "Last 7 days" section, no console errors
- [ ] Visual confirmation after merge — keyboard nav (j/k) over the PRs column still works