### PR TITLE
settings: clearer wording for PAT link

### DIFF
--- a/packages/web/src/components/SettingsModal.tsx
+++ b/packages/web/src/components/SettingsModal.tsx
@@ -29,21 +29,19 @@ function TokenHelp({ url }: { url?: string }) {
   return (
     <p>
       <Text size="small" variant="secondary">
-        Needs <code>repo</code> and <code>notifications</code> scopes
-        {url ? (
+        Needs <code>repo</code> and <code>notifications</code> scopes.
+        {url && (
           <>
-            {" — "}
+            {" "}
             <a
               href={url}
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:text-foreground"
             >
-              create one with the scopes pre-selected
+              Click here to create the token.
             </a>
           </>
-        ) : (
-          "."
         )}
       </Text>
     </p>


### PR DESCRIPTION
Tweaks the TokenHelp copy in the settings modal so the "create one" action reads more like a call-to-action.

Before: \`Needs repo and notifications scopes — create one with the scopes pre-selected\`
After: \`Needs repo and notifications scopes. Click here to create the token.\`

Stacked on #65.