### PR TITLE
release-notes: group PRs by author, minimal format

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Reads GitHub's release-notes body on stdin, prints an author-grouped,
+// minimal changelog block on stdout. One @-tag per contributor, then a
+// flat list of their PR titles.
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  const byUser = new Map();
+  for (const line of input.split("\n")) {
+    const m = line.match(/^\* (.+?) by @(\S+) in .*\/pull\/(\d+)/);
+    if (!m) continue;
+    const [, title, user, num] = m;
+    if (!byUser.has(user)) byUser.set(user, []);
+    byUser.get(user).push({ title, num });
+  }
+  const out = [];
+  for (const [user, prs] of byUser) {
+    out.push(`**@${user}**`);
+    for (const { title, num } of prs) out.push(`- ${title} (#${num})`);
+    out.push("");
+  }
+  process.stdout.write(out.join("\n").trimEnd() + "\n");
+});

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -165,7 +165,8 @@ jobs:
           repo="${{ github.repository }}"
           base_url="https://github.com/${repo}/releases/download/${tag}"
           changelog=$(gh api -X POST "/repos/${repo}/releases/generate-notes" \
-            -f tag_name="$tag" --jq '.body')
+            -f tag_name="$tag" --jq '.body' \
+            | node .github/scripts/release-notes.mjs)
           {
             echo "## Download"
             echo
@@ -175,6 +176,8 @@ jobs:
             echo "Other files in the asset list are consumed by the in-app auto-updater."
             echo
             echo "---"
+            echo
+            echo "## Changes"
             echo
             echo "$changelog"
           } > /tmp/notes.md


### PR DESCRIPTION
## Summary
- Pipe GitHub's `generate-notes` body through a small node parser (`.github/scripts/release-notes.mjs`) that groups merged PRs under one `**@user**` heading per contributor.
- Emits `- title (#N)` bullets instead of the default `* title by @user in <url>` lines.
- Adds a `## Changes` heading above the grouped block.

Preview applied retroactively to v0.0.2-rc.0: https://github.com/AntonNiklasson/github-dashboard/releases/tag/v0.0.2-rc.0

## Test plan
- [x] Smoke-tested parser against a sample changelog locally.
- [x] Regenerated and applied notes to v0.0.2-rc.0 via `gh release edit`.
- [ ] Next release run will exercise the workflow path end-to-end.